### PR TITLE
proposing HeldBlock version 2, backward-compatible with 1

### DIFF
--- a/src/Inventory.c
+++ b/src/Inventory.c
@@ -43,6 +43,23 @@ void Inventory_SetSelectedBlock(BlockID block) {
 	Event_RaiseVoid(&UserEvents.HeldBlockChanged);
 }
 
+void Inventory_SetBlockAtIndex(BlockID block, int index) {
+	int i;
+	if (!Inventory_CheckChangeSelected()) return;
+
+	/* Swap with currently selected block if given block is already in the hotbar */
+	for (i = 0; i < INVENTORY_BLOCKS_PER_HOTBAR; i++) {
+		if (Inventory_Get(i) != block) continue;
+		Inventory_Set(i, Inventory_Get(index));
+		break;
+	}
+
+	Inventory_Set(index, block);
+	if (Inventory.SelectedIndex == index) {
+		Event_RaiseVoid(&UserEvents.HeldBlockChanged);
+	}
+}
+
 static const uint8_t classicInventory[42] = {
 	BLOCK_STONE, BLOCK_COBBLE, BLOCK_BRICK, BLOCK_DIRT, BLOCK_WOOD, BLOCK_LOG, BLOCK_LEAVES, BLOCK_GLASS, BLOCK_SLAB,
 	BLOCK_MOSSY_ROCKS, BLOCK_SAPLING, BLOCK_DANDELION, BLOCK_ROSE, BLOCK_BROWN_SHROOM, BLOCK_RED_SHROOM, BLOCK_SAND, BLOCK_GRAVEL, BLOCK_SPONGE,

--- a/src/Inventory.h
+++ b/src/Inventory.h
@@ -44,6 +44,8 @@ void Inventory_SetHotbarIndex(int index);
 /* Attempts to set the block for the selected index in the current hotbar. */
 /* NOTE: If another slot is already this block, the selected index is instead changed. */
 void Inventory_SetSelectedBlock(BlockID block);
+/* Attempts to set the block at a given index in the current hotbar. */
+void Inventory_SetBlockAtIndex(BlockID block, int index);
 /* Sets all slots to contain their default associated block. */
 /* NOTE: The order of default blocks may not be in order of ID. */
 void Inventory_ApplyDefaultMapping(void);


### PR DESCRIPTION
Proposed by nahkoots
Motivation: The default hotbar may not contain a server's desired arrangement of blocks. However, the existing HoldThis packet only allows for modification of the current selected block. This revision of the HoldThis packet will allow servers to modify an arbitrary hotbar slot, allowing servers to set their own default hotbar or restore a player's hotbar from a previous session.
Client behavior: The client must accept an additional byte with each HoldThis and change the block at the corresponding value. All responsibilities of version 1 also apply.
Server behavior: The server must provide a hotbar slot to modify, or 255 if it wishes to modify the current slot, to clients supporting version 2. All responsibilities of version 1 also apply.
Packet definitions: The HoldThis packet contains an additional byte to indicate which hotbar slot is to be modified. A value of 255 indicates that the current selected slot should be modified (same behavior as version 1).

This code implements the above proposal. Behavior is unchanged when connecting to servers that do not support the revision.