### PR TITLE
Allow for specifiying of custom directory for data

### DIFF
--- a/src/Args.c
+++ b/src/Args.c
@@ -38,6 +38,7 @@ void Args_Parse(int count, const String args[GAME_MAX_CMDARGS]) {
 		for (j = 0; j < ARGS_TYPE_COUNT; ++j) {
 			if (String_CaselessEqualsConst(&args[i], Args_ArgPrefixes[j])) {
 				Args_ArgCache[j] = args[++i];
+				break;
 			}
 		}
 	}

--- a/src/Args.c
+++ b/src/Args.c
@@ -1,0 +1,127 @@
+#include "Args.h"
+#include "Platform.h"
+#include "Constants.h"
+
+/**
+ * Matches up to the ArgsType enum defined in Args.h
+ * When modifying this, don't forget to add the new entry
+ * to the enum
+ */
+static const char *Args_ArgPrefixes[ARGS_TYPE_COUNT] = {
+		"-u", // username
+		"-s", // secret (Password)
+		"-a", // address (IP Address)
+		"-p", // port
+		"-h", // hash
+		"-d"  // directory
+};
+
+static String Args_ArgCache[ARGS_TYPE_COUNT];
+static int Args_Count = 0;
+static String Args_Raw[GAME_MAX_CMDARGS];
+
+void Args_Parse(int count, const String args[GAME_MAX_CMDARGS]) {
+	int i, j;
+	// WIth the new system, every argument must have an identifier
+
+	for (i = 0; i < GAME_MAX_CMDARGS; ++i) {
+		Args_Raw[i] = args[i];
+
+	}
+	Args_Count = count / 2;
+
+	for (i = 0; i < ARGS_TYPE_COUNT; ++i) {
+		Args_ArgCache[i] = String_Empty;
+	}
+
+	for (i = 0; i < count; ++i) {
+		for (j = 0; j < ARGS_TYPE_COUNT; ++j) {
+			if (String_CaselessEqualsConst(&args[i], Args_ArgPrefixes[j])) {
+				Args_ArgCache[j] = args[++i];
+			}
+		}
+	}
+}
+
+int Args_Init(int argc, char **argv) {
+	int count;
+	String args[GAME_MAX_CMDARGS];
+
+	count = Platform_GetCommandLineArgs(argc, argv, args);
+
+	if (count % 2 != 0) {
+		return -1;
+	}
+
+	Args_Parse(count, args);
+
+	return Args_GetArgsCount();
+}
+
+const String *Args_GetUsername(void) {
+	return &Args_ArgCache[ARGS_TYPE_USERNAME];
+}
+
+const String *Args_GetMPPass(void) {
+	return &Args_ArgCache[ARGS_TYPE_MPPASS];
+}
+
+const String *Args_GetIP(void) {
+	return &Args_ArgCache[ARGS_TYPE_IP];
+}
+
+const String *Args_GetPort(void) {
+	return &Args_ArgCache[ARGS_TYPE_PORT];
+}
+
+const String *Args_GetHash(void) {
+	return &Args_ArgCache[ARGS_TYPE_HASH];
+}
+
+const String *Args_GetWorkingDir(void) {
+	return &Args_ArgCache[ARGS_TYPE_WORKING_DIR];
+}
+
+int Args_GetArgsCount(void) {
+	return Args_Count;
+}
+
+cc_bool Args_OnlyHasHash(void) {
+	return Args_GetArgsCount() < 3 && Args_GetHash()->buffer != NULL;
+}
+
+cc_bool Args_OnlyHasUsername(void) {
+	return Args_GetArgsCount() < 3 && Args_GetUsername()->buffer != NULL;
+}
+
+cc_bool Args_HasRunningArgs(void) {
+	return Args_GetUsername()->buffer != NULL &&
+			Args_GetMPPass()->buffer != NULL &&
+			Args_GetIP()->buffer != NULL &&
+			Args_GetPort()->buffer != NULL;
+}
+
+cc_bool Args_HasNoArguments(void) {
+	return Args_GetArgsCount() == 0 ||
+		   (Args_GetWorkingDir()->buffer != NULL && Args_GetArgsCount() == 1);
+}
+
+void Args_SetCustomArgs(const String *raw) {
+	int count;
+	String args[GAME_MAX_CMDARGS];
+	count = String_UNSAFE_Split(raw, ' ', args, 4);
+	Args_Parse(count, args);
+}
+
+const String *Args_GetRawArgs(void) {
+	return Args_Raw;
+}
+
+cc_bool Args_RequestedSpecificDirectory(void) {
+	return Args_GetWorkingDir()->buffer != NULL;
+}
+
+cc_bool Args_HasEnoughArgs(void) {
+	return Args_OnlyHasHash() || Args_OnlyHasUsername() || Args_HasRunningArgs() || Args_HasNoArguments();
+}
+

--- a/src/Args.h
+++ b/src/Args.h
@@ -1,0 +1,55 @@
+#ifndef CC_ARGS_H
+#define CC_ARGS_H
+
+#include "Core.h"
+#include "String.h"
+
+/* Parses and handles arguments
+   Copyright 2014-2019 ClassiCube | Licensed under BSD-3
+*/
+
+enum ArgsType {
+    ARGS_TYPE_USERNAME,
+    ARGS_TYPE_MPPASS,
+    ARGS_TYPE_IP,
+    ARGS_TYPE_PORT,
+    ARGS_TYPE_HASH,
+    ARGS_TYPE_WORKING_DIR,
+    ARGS_TYPE_COUNT
+};
+
+
+/* Returns number of actual arguments not counting identifiers */
+int Args_Init(int argc, char **argv);
+
+void Args_SetCustomArgs(const String *raw);
+
+const String *Args_GetUsername(void);
+
+const String *Args_GetMPPass(void);
+
+const String *Args_GetIP(void);
+
+const String *Args_GetPort(void);
+
+const String *Args_GetHash(void);
+
+const String *Args_GetWorkingDir(void);
+
+int Args_GetArgsCount(void);
+
+const String *Args_GetRawArgs(void);
+
+cc_bool Args_OnlyHasHash(void);
+
+cc_bool Args_OnlyHasUsername(void);
+
+cc_bool Args_HasRunningArgs(void);
+
+cc_bool Args_HasNoArguments(void);
+
+cc_bool Args_RequestedSpecificDirectory(void);
+
+cc_bool Args_HasEnoughArgs(void);
+
+#endif //CC_ARGS_H

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -4,7 +4,7 @@
    Copyright 2014-2019 ClassiCube | Licensed under BSD-3
 */
 
-#define GAME_MAX_CMDARGS 5
+#define GAME_MAX_CMDARGS 12
 #define GAME_APP_VER "1.0.8"
 #define GAME_API_VER 1
 

--- a/src/Launcher.c
+++ b/src/Launcher.c
@@ -15,6 +15,7 @@
 #include "ExtMath.h"
 #include "Funcs.h"
 #include "Logger.h"
+#include "Args.h"
 
 #ifndef CC_BUILD_WEB
 struct LScreen* Launcher_Screen;
@@ -568,8 +569,19 @@ cc_bool Launcher_StartGame(const String* user, const String* mppass, const Strin
 	}
 
 	String_InitArray(args, argsBuffer);
+	String_AppendConst(&args, "-u ");
 	String_AppendString(&args, user);
-	if (mppass->length) String_Format3(&args, " %s %s %s", mppass, ip, port);
+	if (mppass->length) {
+		if (Args_RequestedSpecificDirectory()) {
+			String_Format4(&args, " -s %s -a %s -p %s -d %s", mppass, ip, port, Args_GetWorkingDir());
+		} else {
+			String_Format3(&args, " -s %s -a %s -p %s", mppass, ip, port);
+		}
+	} else {
+		if (Args_RequestedSpecificDirectory()) {
+			String_Format1(&args, " -d %s", Args_GetWorkingDir());
+		}
+	}
 
 	res = Process_StartGame(&args);
 	if (res) { Logger_Warn(res, "starting game"); return false; }

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -41,7 +41,7 @@ void Platform_Init(void);
 /* Frees the platform specific state. */
 void Platform_Free(void);
 /* Sets the appropriate default current/working directory. */
-cc_result Platform_SetDefaultCurrentDirectory(void);
+cc_result Platform_SetDefaultCurrentDirectory(const String *requestedDirectory);
 /* Gets the command line arguments passed to the program. */
 int Platform_GetCommandLineArgs(int argc, STRING_REF char** argv, String* args);
 

--- a/src/Program.c
+++ b/src/Program.c
@@ -84,7 +84,7 @@ CC_NOINLINE static void ExitMissingArgs(int argsCount, const String* args) {
 	int i;
 	String_InitArray(tmp, tmpBuffer);
 
-	String_AppendConst(&tmp, "Missing IP and/or port - ");
+	String_AppendConst(&tmp, "Missing IP and/or port. Or an incorrect number of arguments were passed - ");
 	for (i = 0; i < argsCount; i++) { 
 		String_AppendString(&tmp, &args[i]);
 		String_Append(&tmp, ' ');
@@ -176,16 +176,16 @@ int main(int argc, char** argv) {
 	Logger_Hook();
 	Platform_Init();
 	Window_Init();
-	Args_Init(argc, argv);
+
+	if (Args_Init(argc, argv) < 0) {
+		ExitMissingArgs(Args_GetArgsCount(), Args_GetRawArgs());
+		return 1;
+	}
 
 	if (Args_RequestedSpecificDirectory()) {
-
-
-
+		res = Platform_SetDefaultCurrentDirectory(Args_GetWorkingDir());
 	} else {
-
-		res = Platform_SetDefaultCurrentDirectory();
-
+		res = Platform_SetDefaultCurrentDirectory(NULL);
 	}
 
 	if (res) Logger_Warn(res, "setting current directory");


### PR DESCRIPTION
Reworked the way arguments are done, and allow for the specifying of a custom directory for ClassiCube to work from. If this is merged, I will add ClassiCube to the Arch User Repository. These changes were tested on a linux distribution, but should work fine elsewhere as most of it is platform independent. The part that is platform independent was basically the same change that works fine on Linux. Let me know what I need to change.