### PR TITLE
Makefile: Use no-math-errno flag for all GCC compilers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ ENAME=ClassiCube
 DEL=rm
 JOBS=1
 CC=gcc
-CFLAGS=-g -pipe -rdynamic
+CFLAGS=-g -pipe -rdynamic -fno-math-errno
 LDFLAGS=-g -rdynamic
 
 ifndef $(PLAT)
@@ -24,7 +24,7 @@ endif
 
 ifeq ($(PLAT),mingw)
 OEXT=.exe
-CFLAGS=-g -pipe -DUNICODE
+CFLAGS=-g -pipe -DUNICODE -fno-math-errno
 LDFLAGS=-g
 LIBS=-mwindows -lws2_32 -lwininet -lwinmm -limagehlp -lcrypt32 -ld3d9
 endif
@@ -50,19 +50,19 @@ LIBS=-lcurl -lexecinfo -lopenal -lGL -lX11 -lm -lpthread
 endif
 
 ifeq ($(PLAT),openbsd)
-CFLAGS=-g -pipe -rdynamic -I /usr/X11R6/include -I /usr/local/include
+CFLAGS=-g -pipe -rdynamic -I /usr/X11R6/include -I /usr/local/include -fno-math-errno
 LDFLAGS=-L /usr/X11R6/lib -L /usr/local/lib
 LIBS=-lcurl -lexecinfo -lopenal -lGL -lX11
 endif
 
 ifeq ($(PLAT),netbsd)
-CFLAGS=-g -pipe -rdynamic -I /usr/X11R7/include -I /usr/pkg/include
+CFLAGS=-g -pipe -rdynamic -I /usr/X11R7/include -I /usr/pkg/include -fno-math-errno
 LDFLAGS=-L /usr/X11R7/lib -L /usr/pkg/lib
 LIBS=-lcurl -lexecinfo -lopenal -lGL -lX11
 endif
 
 ifeq ($(PLAT),haiku)
-CFLAGS=-g -pipe
+CFLAGS=-g -pipe -fno-math-errno
 LDFLAGS=-g
 LIBS=-lcurl -lm -lexecinfo -lopenal -lGL -lnetwork -lSDL2
 endif


### PR DESCRIPTION
Changes the CFLAGS for all platforms which use the GCC compiler
to include -fno-math-errno in order to resolve a linking issue
when compiling for platforms that use GCC.

For some reason, the flag was not added to the Makefile in [commit
1a5f96](https://github.com/UnknownShadow200/ClassiCube/commit/1a5f963ef0b49cfb44a9bcfa9dc355bdfee532fd), which replaces AbsF and SqrtF with their respective GCC
built-ins.
