### PR TITLE
Chat: create new 'use classic chat' option

### DIFF
--- a/src/Gui.c
+++ b/src/Gui.c
@@ -13,7 +13,7 @@
 #include "Bitmap.h"
 #include "Options.h"
 
-cc_bool Gui_ClassicTexture, Gui_ClassicTabList, Gui_ClassicMenu;
+cc_bool Gui_ClassicTexture, Gui_ClassicTabList, Gui_ClassicMenu, Gui_ClassicChat;
 int     Gui_Chatlines;
 cc_bool Gui_ClickableChat, Gui_TabAutocomplete, Gui_ShowFPS;
 
@@ -98,6 +98,7 @@ static void Gui_LoadOptions(void) {
 	Gui_ClassicTexture = Options_GetBool(OPT_CLASSIC_GUI, true)      || Game_ClassicMode;
 	Gui_ClassicTabList = Options_GetBool(OPT_CLASSIC_TABLIST, false) || Game_ClassicMode;
 	Gui_ClassicMenu    = Options_GetBool(OPT_CLASSIC_OPTIONS, false) || Game_ClassicMode;
+	Gui_ClassicChat    = Options_GetBool(OPT_CLASSIC_CHAT, false)    || Game_PureClassic;
 	Gui_ShowFPS        = Options_GetBool(OPT_SHOW_FPS, true);
 }
 

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -24,6 +24,8 @@ extern cc_bool Gui_ClassicTexture;
 extern cc_bool Gui_ClassicTabList;
 /* Whether menus are laid out like vanilla Minecraft Classic. */
 extern cc_bool Gui_ClassicMenu;
+/* Whether classic-style chat screen is used */
+extern cc_bool Gui_ClassicChat;
 /* Maximum number of visible chatlines on screen. Can be 0. */
 extern int     Gui_Chatlines;
 /* Whether clicking on a chatline inserts it into chat input. */

--- a/src/Menus.c
+++ b/src/Menus.c
@@ -2903,6 +2903,9 @@ static void NostalgiaScreen_SetCPE(const String* v) { Game_UseCPE = Menu_SetBool
 static void NostalgiaScreen_GetTexs(String* v) { Menu_GetBool(v, Game_AllowServerTextures); }
 static void NostalgiaScreen_SetTexs(const String* v) { Game_AllowServerTextures = Menu_SetBool(v, OPT_SERVER_TEXTURES); }
 
+static void NostalgiaScreen_GetClassicChat(String* v) { Menu_GetBool(v, Gui_ClassicChat); }
+static void NostalgiaScreen_SetClassicChat(const String* v) { Gui_ClassicChat = Menu_SetBool(v, OPT_CLASSIC_CHAT); }
+
 static void NostalgiaScreen_SwitchBack(void* a, void* b) {
 	if (Gui_ClassicMenu) { Menu_SwitchPause(a, b); } else { Menu_SwitchOptions(a, b); }
 }
@@ -2913,7 +2916,7 @@ static void NostalgiaScreen_RecreateExtra(struct MenuOptionsScreen* s) {
 }
 
 static void NostalgiaScreen_InitWidgets(struct MenuOptionsScreen* s) {
-	static const struct MenuOptionDesc buttons[8] = {
+	static const struct MenuOptionDesc buttons[9] = {
 		{ -1, -150, "Classic hand model",   MenuOptionsScreen_Bool,
 			NostalgiaScreen_GetHand,   NostalgiaScreen_SetHand },
 		{ -1, -100, "Classic walk anim",    MenuOptionsScreen_Bool,
@@ -2931,12 +2934,14 @@ static void NostalgiaScreen_InitWidgets(struct MenuOptionsScreen* s) {
 			NostalgiaScreen_GetCPE,    NostalgiaScreen_SetCPE },
 		{ 1,  -50, "Use server textures", MenuOptionsScreen_Bool,
 			NostalgiaScreen_GetTexs,   NostalgiaScreen_SetTexs },
+        { 1,    0, "Use classic chat",    MenuOptionsScreen_Bool,
+            NostalgiaScreen_GetClassicChat, NostalgiaScreen_SetClassicChat },
 	};
-	s->numWidgets      = 8 + 1 + MENUOPTIONS_CORE_WIDGETS;
+	s->numWidgets      = 9 + 1 + MENUOPTIONS_CORE_WIDGETS;
 	s->DoRecreateExtra = NostalgiaScreen_RecreateExtra;
 
 	MenuOptionsScreen_InitButtons(s, buttons, Array_Elems(buttons), NostalgiaScreen_SwitchBack);
-	Menu_Label(s, 8, &nostalgia_desc, ANCHOR_CENTRE, ANCHOR_CENTRE, 0, 100);
+	Menu_Label(s, 9, &nostalgia_desc, ANCHOR_CENTRE, ANCHOR_CENTRE, 0, 100);
 }
 
 void NostalgiaScreen_Show(void) {

--- a/src/Options.h
+++ b/src/Options.h
@@ -65,6 +65,7 @@
 #define OPT_CLASSIC_OPTIONS "nostalgia-classicoptions"
 #define OPT_CLASSIC_HACKS "nostalgia-hacks"
 #define OPT_CLASSIC_ARM_MODEL "nostalgia-classicarm"
+#define OPT_CLASSIC_CHAT "nostalgia-classicchat"
 #define OPT_MAX_CHUNK_UPDATES "gfx-maxchunkupdates"
 
 extern struct EntryList Options;

--- a/src/Screens.c
+++ b/src/Screens.c
@@ -952,7 +952,7 @@ static void ChatScreen_Render(void* screen, double delta) {
 		ChatScreen_DrawCrosshairs();
 		Gfx_SetTexturing(false);
 	}
-	if (s->grabsInput && !Game_PureClassic) {
+	if (s->grabsInput && !Gui_ClassicChat) {
 		ChatScreen_DrawChatBackground(s);
 	}
 

--- a/src/Widgets.c
+++ b/src/Widgets.c
@@ -1600,7 +1600,7 @@ static void ChatInputWidget_Render(void* widget, double delta) {
 		caretAtEnd = (w->caretY == i) && (w->caretX == INPUTWIDGET_LEN || w->caretPos == -1);
 		width      = w->lineWidths[i] + (caretAtEnd ? w->caretTex.Width : 0);
 		/* Cover whole window width to match original classic behaviour */
-		if (Game_PureClassic) { width = max(width, Window_Width - x * 4); }
+		if (Gui_ClassicChat) { width = max(width, Window_Width - x * 4); }
 	
 		Gfx_Draw2DFlat(x, y, width + w->padding * 2, w->lineHeight, backCol);
 		y += w->lineHeight;


### PR DESCRIPTION
Adds a new option to the Nostalgia category to enable or disable
the classic chat style.

The flag `Gui_ClassicChat` is also enabled whenever the client is in
classic mode, and replaces the new flag replaces the `PureClassic`
checks.

Closes #632