### PR TITLE
Future proof libcurl and libopenal loading on OpenBSD.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Although the regular linux compiliation flags will work fine, to take full advan
 
 #### OpenBSD
 
-Install libexecinfo package if needed.
+Install libexecinfo, curl and openal package if needed.
 
 ```cc *.c -o ClassiCube -I /usr/X11R6/include -I /usr/local/include -L /usr/X11R6/lib -L /usr/local/lib -lm -lpthread -lX11 -lXi -lGL -lexecinfo```
 

--- a/src/Audio.c
+++ b/src/Audio.c
@@ -119,7 +119,7 @@ static const String alLib = String_FromConst("openal32.dll");
 #elif defined CC_BUILD_OSX
 static const String alLib = String_FromConst("/System/Library/Frameworks/OpenAL.framework/Versions/A/OpenAL");
 #elif defined CC_BUILD_OPENBSD
-static const String alLib = String_FromConst("libopenal.so.3.0");
+static const String alLib = String_FromConst("libopenal.so");
 #else
 static const String alLib = String_FromConst("libopenal.so.1");
 #endif

--- a/src/Http.c
+++ b/src/Http.c
@@ -487,8 +487,8 @@ static const String curlAlt = String_FromConst("curl.dll");
 static const String curlLib = String_FromConst("/usr/lib/libcurl.4.dylib");
 static const String curlAlt = String_FromConst("/usr/lib/libcurl.dylib");
 #elif defined CC_BUILD_OPENBSD
-static const String curlLib = String_FromConst("libcurl.so.25.17");
-static const String curlAlt = String_FromConst("libcurl.so.25.16");
+static const String curlLib = String_FromConst("libcurl.so");
+static const String curlAlt = String_FromConst("libcurl.so");
 #else
 static const String curlLib = String_FromConst("libcurl.so.4");
 static const String curlAlt = String_FromConst("libcurl.so.3");


### PR DESCRIPTION
ld.so does the right thing even without hardcoded versions.
Also mention curl and openal as dependencies.

---------------------

I run Snapshots which of course has different libcurl and libopenal version numbers, as does OpenBSD 6.7. But ld.so picks the right version by default. Since curl an openal is installed by package it's pretty much guaranteed that there is only one version installed at any time.

A quick man page check suggests that NetBSD does the same thing. Not sure about FreeBSD and others.