### PR TITLE
Auto adjust game resolution on mobile device rotation  (web client)

### DIFF
--- a/src/Window.c
+++ b/src/Window.c
@@ -3420,7 +3420,7 @@ void Clipboard_RequestText(RequestClipboardCallback callback, void* obj) {
 void Window_Show(void) { }
 
 int Window_GetWindowState(void) {
-	EmscriptenFullscreenChangeEvent status;
+	EmscriptenFullscreenChangeEvent status = { 0 };
 	emscripten_get_fullscreen_status(&status);
 	return status.isFullscreen ? WINDOW_STATE_FULLSCREEN : WINDOW_STATE_NORMAL;
 }


### PR DESCRIPTION
Need to test behaves correctly on

- [X] Chrome for android
- [X] Firefox for android
- [X] Safari for ios

And make sure doesn't cause issues with fullscreen resolution in desktop browsers
- [X] Chrome
- [X] Firefox
- [X] Safari
- [X] IE11
- [ ] Edge
- [X] Edge Chromium
- [X] ~~Opera fullscreen doesn't behave properly anyways~~