### PR TITLE
Update readme.md, properly.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,10 +31,13 @@ Run ClassiCube.exe, then click Singleplayer at the main menu.
 **Multiplayer**
 Run ClassiCube.exe. You can connect to LAN/locally hosted servers, ~~minecraft.net servers,~~ and classicube.net servers through the launcher.
 
-###### *Stuck on OpenGL 1.1?*
-Compile the game yourself with the following flag described below. For compiling the game, see the corresponding command for your operating system. 
+###### *Stuck with OpenGL 1.1 due to old graphics hardware?*
+Compile the game yourself with the following flag described below. For compiling the game, see the corresponding command for BSD, macOS (32 bit or 64 bit), or Linux operating systems. 
 
-*If you are need to use the OpenGL 1.1 software renderer due to a non upgradable, older GPU, such as an ATI RAGE series card in an older laptop or PowerPC Mac with an integrated RAGE chip, add `-DCC_BUILD_GL11` as a compilation flag **before the optimize flag**.
+*If you need to use the OpenGL 1.1 hardware renderer due to a non upgradable, older GPU, such as an ATI RAGE series card in an older laptop or PowerPC Mac with an integrated ATI or nVidia chip, add `-DCC_BUILD_GL11` as a compilation flag **before the optimize flag**. The game **will not run** without this flag on older GPUs under the above operating systems.
+
+###### *Windows specific*
+*If you are stuck using the built-in OpenGL 1.1 software renderer, you can use the MESA software renderer from [here](http://download.qt.io/development_releases/prebuilt/llvmpipe/windows/) for slightly better performance. Typically though, this occurs because you have not installed GPU drivers.*
 
 ### Compiling - Windows
 

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ Run ClassiCube.exe, then click Singleplayer at the main menu.
 **Multiplayer**
 Run ClassiCube.exe. You can connect to LAN/locally hosted servers, ~~minecraft.net servers,~~ and classicube.net servers through the launcher.
 
-###### *Windows specific*
-*If you are stuck using the built-in OpenGL 1.1 software renderer, you can use the MESA software renderer from [here](http://download.qt.io/development_releases/prebuilt/llvmpipe/windows/) for slightly better performance. Typically though, this occurs because you have not installed GPU drivers.*
+###### *Stuck on OpenGL 1.1?*
+*If you are need to use the OpenGL 1.1 software renderer due to a non upgradable, older GPU, such as an ATI RAGE series card in an older laptop or PowerPC Mac with an integrated RAGE chip, add `-DCC_BUILD_GL11` as a compilation flag **before the optimize flag**.
 
 ### Compiling - Windows
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@ Run ClassiCube.exe, then click Singleplayer at the main menu.
 Run ClassiCube.exe. You can connect to LAN/locally hosted servers, ~~minecraft.net servers,~~ and classicube.net servers through the launcher.
 
 ###### *Stuck on OpenGL 1.1?*
+Compile the game yourself with the following flag described below. For compiling the game, see the corresponding command for your operating system. 
+
 *If you are need to use the OpenGL 1.1 software renderer due to a non upgradable, older GPU, such as an ATI RAGE series card in an older laptop or PowerPC Mac with an integrated RAGE chip, add `-DCC_BUILD_GL11` as a compilation flag **before the optimize flag**.
 
 ### Compiling - Windows


### PR DESCRIPTION
Replaced Windows specific section with section detailing what to do to compile ClassiCube to work on integrated GPUs that only support OpenGL 1.1, and where specifically to place the flag in order to compile it successfully.