### PR TITLE
Add hold model

### DIFF
--- a/src/Model.c
+++ b/src/Model.c
@@ -2118,8 +2118,8 @@ static void SkinnedCubeModel_Register(void) {
 *#########################################################################################################################*/
 static void RecalcProperties(struct Entity* e) {
 	// Calculate block ID based on the X scale of the model
-	// E.g, hold|1.0001 = stone (ID = 1), hold|1.0041 = gold (ID = 41) etc.
-	BlockID block = (BlockID)((e->ModelScale.X - 0.99999f) * 10000);
+	// E.g, hold|1.001 = stone (ID = 1), hold|1.041 = gold (ID = 41) etc.
+	BlockID block = (BlockID)((e->ModelScale.X - 0.9999f) * 1000);
 
 	if (block > 0) {
 		// Change the block that the player is holding
@@ -2127,6 +2127,7 @@ static void RecalcProperties(struct Entity* e) {
 		else e->ModelBlock = BLOCK_AIR;
 
 		Vec3_Set(e->ModelScale, 1, 1, 1);
+		Entity_UpdateModelBounds(e); // Adjust size/modelAABB after changing model scale
 	}
 }
 
@@ -2168,11 +2169,18 @@ static void HoldModel_Draw(struct Entity* e) {
 }
 
 static struct Model hold_model;
+
+static float HoldModel_GetEyeY(struct Entity* e) {
+	RecalcProperties(e);
+	return HumanModel_GetEyeY(e);
+}
+
 static void HoldModel_Register(void) {
 	hold_model = human_model;
 	hold_model.name = "hold";
 	hold_model.MakeParts = Model_NoParts;
 	hold_model.Draw = HoldModel_Draw;
+	hold_model.GetEyeY = HoldModel_GetEyeY;
 	Model_Register(&hold_model);
 }
 

--- a/src/Model.c
+++ b/src/Model.c
@@ -2116,10 +2116,10 @@ static void SkinnedCubeModel_Register(void) {
 /*########################################################################################################################*
 *---------------------------------------------------------HoldModel-------------------------------------------------------*
 *#########################################################################################################################*/
-static struct Model* blockModel;
-
 static void RecalcProperties(struct Entity* e) {
-	BlockID block = (BlockID)((e->ModelScale.X - 0.9999f) * 1000);
+	// Calculate block ID based on the X scale of the model
+	// E.g, hold|1.0001 = stone (ID = 1), hold|1.0041 = gold (ID = 41) etc.
+	BlockID block = (BlockID)((e->ModelScale.X - 0.99999f) * 10000);
 
 	if (block > 0) {
 		// Change the block that the player is holding
@@ -2134,21 +2134,19 @@ static void DrawBlockTransform(struct Entity* e, float dispX, float dispY, float
 	static Vec3 pos;
 	static struct Matrix m, temp;
 
-	if (block_model) {
-		pos = e->Position;
-		pos.Y += e->Anim.BobbingModel;
+	pos = e->Position;
+	pos.Y += e->Anim.BobbingModel;
 
-		Entity_GetTransform(e, pos, e->ModelScale, &m);
-		Matrix_Mul(&m, &m, &Gfx.View);
-		Matrix_Translate(&temp, dispX, dispY, dispZ);
-		Matrix_Mul(&m, &temp, &m);
-		Matrix_Scale(&temp, scale / 1.5f, scale / 1.5f, scale / 1.5f);
-		Matrix_Mul(&m, &temp, &m);
+	Entity_GetTransform(e, pos, e->ModelScale, &m);
+	Matrix_Mul(&m, &m, &Gfx.View);
+	Matrix_Translate(&temp, dispX, dispY, dispZ);
+	Matrix_Mul(&m, &temp, &m);
+	Matrix_Scale(&temp, scale / 1.5f, scale / 1.5f, scale / 1.5f);
+	Matrix_Mul(&m, &temp, &m);
 
-		Model_SetupState(block_model, e);
-		Gfx_LoadMatrix(MATRIX_VIEW, &m);
-		block_model->Draw(e);
-	}
+	Model_SetupState(&block_model, e);
+	Gfx_LoadMatrix(MATRIX_VIEW, &m);
+	block_model.Draw(e);
 }
 
 static void HoldModel_Draw(struct Entity* e) {


### PR DESCRIPTION
I know this is a bit of a hacky work-around but I think it could be beneficial to allow players to be able to see blocks they're holding (will make an MCGalaxy plugin later in support of this). Could be useful for the time being until (if) something like #153 is implemented.