### PR TITLE
Make BlockPermissions affect gas blocks better

### DIFF
--- a/src/Input.c
+++ b/src/Input.c
@@ -738,6 +738,12 @@ void InputHandler_PlaceBlock(void) {
 	if (Game_CanPick(old) || !Blocks.CanPlace[block]) return;
 	/* air-ish blocks can only replace over other air-ish blocks */
 	if (Blocks.Draw[block] == DRAW_GAS && Blocks.Draw[old] != DRAW_GAS) return;
+
+	/* undeletable non-solid blocks can't be replaced with other blocks */
+	if ((Blocks.Collide[old] == COLLIDE_GAS || Blocks.Collide[old] == COLLIDE_LIQUID
+	    || Blocks.Collide[old] == COLLIDE_LIQUID_LAVA || Blocks.Collide[old] == COLLIDE_LIQUID_WATER)
+	    && !Blocks.CanDelete[old]) return;
+
 	if (!CheckIsFree(block)) return;
 
 	Game_ChangeBlock(pos.X, pos.Y, pos.Z, block);

--- a/src/Input.c
+++ b/src/Input.c
@@ -740,9 +740,8 @@ void InputHandler_PlaceBlock(void) {
 	if (Blocks.Draw[block] == DRAW_GAS && Blocks.Draw[old] != DRAW_GAS) return;
 
 	/* undeletable non-solid blocks can't be replaced with other blocks */
-	if ((Blocks.Collide[old] == COLLIDE_GAS || Blocks.Collide[old] == COLLIDE_LIQUID
-	    || Blocks.Collide[old] == COLLIDE_LIQUID_LAVA || Blocks.Collide[old] == COLLIDE_LIQUID_WATER)
-	    && !Blocks.CanDelete[old]) return;
+	if ((Blocks.Collide[old] == COLLIDE_GAS || Blocks.Collide[old] == COLLIDE_LIQUID)
+	   && !Blocks.CanDelete[old]) return;
 
 	if (!CheckIsFree(block)) return;
 

--- a/src/Input.c
+++ b/src/Input.c
@@ -739,9 +739,8 @@ void InputHandler_PlaceBlock(void) {
 	/* air-ish blocks can only replace over other air-ish blocks */
 	if (Blocks.Draw[block] == DRAW_GAS && Blocks.Draw[old] != DRAW_GAS) return;
 
-	/* undeletable non-solid blocks can't be replaced with other blocks */
-	if ((Blocks.Collide[old] == COLLIDE_GAS || Blocks.Collide[old] == COLLIDE_LIQUID)
-	   && !Blocks.CanDelete[old]) return;
+	/* undeletable gas blocks can't be replaced with other blocks */
+	if (Blocks.Collide[old] == COLLIDE_GAS && !Blocks.CanDelete[old]) return;
 
 	if (!CheckIsFree(block)) return;
 

--- a/src/Server.c
+++ b/src/Server.c
@@ -296,7 +296,6 @@ static void MPConnection_BeginConnect(void) {
 	String_InitArray(title, titleBuffer);
 
 	/* Default block permissions (in case server supports SetBlockPermissions but doesn't send) */
-	Blocks.CanPlace[BLOCK_AIR] = false;         Blocks.CanDelete[BLOCK_AIR] = false;
 	Blocks.CanPlace[BLOCK_LAVA] = false;        Blocks.CanDelete[BLOCK_LAVA] = false;
 	Blocks.CanPlace[BLOCK_WATER] = false;       Blocks.CanDelete[BLOCK_WATER] = false;
 	Blocks.CanPlace[BLOCK_STILL_LAVA] = false;  Blocks.CanDelete[BLOCK_STILL_LAVA] = false;


### PR DESCRIPTION
Currently setting a non-solid block to be undeletable doesn't do anything, as you can still replace it with other blocks. This change will make it so that if a non-solid block is undeletable, the client cannot replace the block with anything else.