### PR TITLE
Audio fixup part 3

### DIFF
--- a/src/Audio.c
+++ b/src/Audio.c
@@ -220,7 +220,7 @@ void Audio_Close(struct AudioContext* ctx) {
 		Audio_Reset(ctx);
 		_alGetError();
 	}
-	ClearFree(ctx->source);
+	ClearFree(ctx);
 	AudioBase_Clear(ctx);
 }
 

--- a/src/Audio.c
+++ b/src/Audio.c
@@ -255,7 +255,7 @@ cc_result Audio_Play(struct AudioContext* ctx) {
 }
 
 static void AudioBackend_Stop(struct AudioContext* ctx) {
-	if (ctx->source == -1) return;
+	if (!ctx->source) return;
 
 	_alSourceStop(ctx->source);
 	_alGetError();

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -30,10 +30,6 @@ void Audio_PlayStepSound(cc_uint8 type);
 void Audio_Init(struct AudioContext* ctx, int buffers);
 /* Stops any playing audio and then frees the audio context. */
 void Audio_Close(struct AudioContext* ctx);
-/* Returns number of channels of the format audio is played in. */
-int Audio_GetChannels(struct AudioContext* ctx);
-/* Returns number of channels of the format audio is played in. */
-int Audio_GetSampleRate(struct AudioContext* ctx);
 /* Sets the format of the audio data to be played. */
 /* NOTE: Changing the format can be expensive, depending on the backend. */
 cc_result Audio_SetFormat(struct AudioContext* ctx, int channels, int sampleRate);
@@ -48,5 +44,9 @@ cc_result Audio_Play(struct AudioContext* ctx);
 /* (e.g. if inUse is 0, no audio buffers are being played or queued) */
 cc_result Audio_Poll(struct AudioContext* ctx, int* inUse);
 
+/* Plays the given audio data at the given volume */
 cc_result Audio_PlaySound(struct AudioContext* ctx, struct Sound* snd, int volume);
+/* Whether the given audio context can play audio data in the given format */
+/*  without recreating the underlying audio device */
+cc_bool Audio_FastPlay(struct AudioContext* ctx, int channels, int sampleRate);
 #endif

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -46,7 +46,9 @@ cc_result Audio_Poll(struct AudioContext* ctx, int* inUse);
 
 /* Plays the given audio data at the given volume */
 cc_result Audio_PlaySound(struct AudioContext* ctx, struct Sound* snd, int volume);
-/* Whether the given audio context can play audio data in the given format */
+/* Whether the given audio context can play audio data in the given format, */
 /*  without recreating the underlying audio device */
 cc_bool Audio_FastPlay(struct AudioContext* ctx, int channels, int sampleRate);
+/* Outputs more detailed information about errors with audio. */
+cc_bool Audio_DescribeError(cc_result res, cc_string* dst);
 #endif


### PR DESCRIPTION
* Log audio-specific error messages
* Better abstract logic for whether an audio context can efficiently play a sound (e.g. OpenAL backend doesn't need to recreate device for differing channel/sample rate)
* Allow backends to override all Audio_ functions

Required testing
- [x] Windows
- [x] Linux
- [x] Web
- [x] Android