### PR TITLE
Simplify window creation

### DIFF
--- a/android/app/src/main/java/com/classicube/MainActivity.java
+++ b/android/app/src/main/java/com/classicube/MainActivity.java
@@ -312,6 +312,7 @@ public class MainActivity extends Activity {
 	public void onDestroy() {
 		Log.i("CC_WIN", "APP DESTROYED");
 		super.onDestroy();
+		pushCmd(CMD_APP_DESTROY);
 	}
 	
 	// Called by the game thread to actually process events

--- a/src/Core.h
+++ b/src/Core.h
@@ -166,7 +166,6 @@ Thus it is **NOT SAFE** to allocate a string on the stack. */
 #define CC_BUILD_EGL
 #define CC_BUILD_TOUCH
 #define CC_BUILD_OPENSLES
-#define CC_NOMAIN
 #elif defined __linux__
 #define CC_BUILD_LINUX
 #define CC_BUILD_POSIX
@@ -189,7 +188,6 @@ Thus it is **NOT SAFE** to allocate a string on the stack. */
 #define CC_BUILD_GLMODERN
 #define CC_BUILD_IOS
 #define CC_BUILD_TOUCH
-#define CC_NOMAIN
 #elif defined __x86_64__ || defined __arm64__
 #define CC_BUILD_COCOA
 #define CC_BUILD_MACOS

--- a/src/Game.c
+++ b/src/Game.c
@@ -663,7 +663,7 @@ static void Game_RunLoop(void) {
 #endif
 
 void Game_Run(int width, int height, const cc_string* title) {
-	Window_Create(width, height);
+	Window_Create3D(width, height);
 	Window_SetTitle(title);
 	Window_Show();
 

--- a/src/Game.c
+++ b/src/Game.c
@@ -662,25 +662,13 @@ static void Game_RunLoop(void) {
 }
 #endif
 
+void Game_Run(int width, int height, const cc_string* title) {
 #ifdef CC_BUILD_ANDROID
-extern cc_bool Window_RemakeSurface(void);
-static cc_bool SwitchToGame() {
 	/* Reset components */
 	Platform_LogConst("undoing components");
 	Drawer2D_Component.Free();
 	//Http_Component.Free();
-	return Window_RemakeSurface();
-}
 #endif
-
-void Game_Run(int width, int height, const cc_string* title) {
-#ifdef CC_BUILD_ANDROID
-	/* Android won't let us change pixel surface to EGL surface */
-	/* So unfortunately have to completely recreate the surface */
-	if (!SwitchToGame()) return;
-	Window_EnterFullscreen();
-#endif
-
 	Window_Create(width, height);
 	Window_SetTitle(title);
 	Window_Show();

--- a/src/Game.c
+++ b/src/Game.c
@@ -663,12 +663,6 @@ static void Game_RunLoop(void) {
 #endif
 
 void Game_Run(int width, int height, const cc_string* title) {
-#ifdef CC_BUILD_ANDROID
-	/* Reset components */
-	Platform_LogConst("undoing components");
-	Drawer2D_Component.Free();
-	//Http_Component.Free();
-#endif
 	Window_Create(width, height);
 	Window_SetTitle(title);
 	Window_Show();

--- a/src/Http_Worker.c
+++ b/src/Http_Worker.c
@@ -794,6 +794,7 @@ static void WorkerLoop(void) {
 static void Http_Init(void) {
 	httpOnly = Options_GetBool(OPT_HTTP_ONLY, false);
 	ScheduledTask_Add(30, Http_CleanCacheTask);
+	/* Http component gets initialised multiple times on Android */
 	if (workerThread) return;
 
 	HttpBackend_Init();

--- a/src/Launcher.c
+++ b/src/Launcher.c
@@ -278,7 +278,7 @@ static void Launcher_Free(void) {
 
 void Launcher_Run(void) {
 	static const cc_string title = String_FromConst(GAME_APP_TITLE);
-	Window_Create(640, 400);
+	Window_Create2D(640, 400);
 #ifdef CC_BUILD_MOBILE
 	Window_LockLandscapeOrientation(Options_GetBool(OPT_LANDSCAPE_MODE, false));
 #endif

--- a/src/Launcher.c
+++ b/src/Launcher.c
@@ -329,16 +329,13 @@ void Launcher_Run(void) {
 	Launcher_Free();
 
 #ifdef CC_BUILD_MOBILE
-	extern int Program_Run(int argc, char** argv);
-	extern cc_bool Window_RemakeSurface(void);
-
-	if (Launcher_ShouldExit) {
-		Launcher_ShouldExit = false;
-		Http_Component.Free();
-		Program_Run(0, NULL);
-		Launcher_Run();
-	}
-#endif
+	/* infinite loop on mobile */
+	Launcher_ShouldExit = false;
+	/* Reset components */
+	Platform_LogConst("undoing components");
+	Drawer2D_Component.Free();
+	Http_Component.Free();
+#else
 	if (Launcher_ShouldUpdate) {
 		const char* action;
 		cc_result res = Updater_Start(&action);
@@ -346,6 +343,7 @@ void Launcher_Run(void) {
 	}
 
 	if (WindowInfo.Exists) Window_Close();
+#endif
 }
 
 

--- a/src/Launcher.c
+++ b/src/Launcher.c
@@ -280,7 +280,6 @@ void Launcher_Run(void) {
 	static const cc_string title = String_FromConst(GAME_APP_TITLE);
 	Window_Create(640, 400);
 #ifdef CC_BUILD_MOBILE
-	Window_EnterFullscreen();
 	Window_LockLandscapeOrientation(Options_GetBool(OPT_LANDSCAPE_MODE, false));
 #endif
 	Window_SetTitle(&title);
@@ -336,10 +335,7 @@ void Launcher_Run(void) {
 	if (Launcher_ShouldExit) {
 		Launcher_ShouldExit = false;
 		Http_Component.Free();
-
 		Program_Run(0, NULL);
-		Window_ExitFullscreen(); /* TODO remove */
-		Window_RemakeSurface();
 		Launcher_Run();
 	}
 #endif

--- a/src/Platform_Posix.c
+++ b/src/Platform_Posix.c
@@ -1227,8 +1227,13 @@ cc_result Platform_Decrypt(const void* data, int len, cc_string* dst) {
 *#########################################################################################################################*/
 #if defined CC_BUILD_ANDROID
 int Platform_GetCommandLineArgs(int argc, STRING_REF char** argv, cc_string* args) {
-	if (!gameArgs.length) return 0;
-	return String_UNSAFE_Split(&gameArgs, ' ', args, GAME_MAX_CMDARGS);
+	int count = 0;
+	if (gameArgs.length) {
+		count = String_UNSAFE_Split(&gameArgs, ' ', args, GAME_MAX_CMDARGS);
+		/* clear arguments so after game is closed, launcher is started */
+		gameArgs.length = 0;
+	}
+	return count;
 }
 
 cc_result Platform_SetDefaultCurrentDirectory(int argc, char **argv) {

--- a/src/Window.h
+++ b/src/Window.h
@@ -79,8 +79,12 @@ CC_VAR extern struct _WinData {
 
 /* Initialises state for window. Also sets Display_ members. */
 void Window_Init(void);
-/* Creates the window as the given size at centre of the screen. */
-void Window_Create(int width, int height);
+/* Creates a window of the given size at centre of the screen. */
+/* NOTE: The created window is compatible with 2D drawing */
+void Window_Create2D(int width, int height);
+/* Creates a window of the given size at centre of the screen. */
+/* NOTE: The created window is compatible with 3D rendering */
+void Window_Create3D(int width, int height);
 /* Sets the text of the titlebar above the window. */
 CC_API void Window_SetTitle(const cc_string* title);
 

--- a/src/Window_Android.c
+++ b/src/Window_Android.c
@@ -174,7 +174,7 @@ static void JNICALL java_onDestroy(JNIEnv* env, jobject o) {
 
 	if (WindowInfo.Exists) Window_Close();
 	/* TODO: signal to java code we're done */
-	JavaCallVoid(env, "processedDestroyed", "()V", NULL);
+	/* JavaCallVoid(env, "processedDestroyed", "()V", NULL); */
 }
 
 static void JNICALL java_onGotFocus(JNIEnv* env, jobject o) {
@@ -259,7 +259,7 @@ static void DoCreateWindow(void) {
 	/* actual window creation is done when processSurfaceCreated is received */
 	Window_RemakeSurface();
 	/* always start as fullscreen */
-	Window_EnterFullscrene();
+	Window_EnterFullscreen();
 }
 void Window_Create2D(int width, int height) { DoCreateWindow(); }
 void Window_Create3D(int width, int height) { DoCreateWindow(); }

--- a/src/Window_Android.c
+++ b/src/Window_Android.c
@@ -10,6 +10,7 @@
 #include <android/native_window_jni.h>
 #include <android/keycodes.h>
 static ANativeWindow* win_handle;
+static cc_bool winCreated;
 
 static void RefreshWindowBounds(void) {
 	WindowInfo.Width  = ANativeWindow_getWidth(win_handle);
@@ -121,6 +122,7 @@ static void JNICALL java_processPointerMove(JNIEnv* env, jobject o, jint id, jin
 static void JNICALL java_processSurfaceCreated(JNIEnv* env, jobject o, jobject surface) {
 	Platform_LogConst("WIN - CREATED");
 	win_handle        = ANativeWindow_fromSurface(env, surface);
+	winCreated        = true;
 	WindowInfo.Handle = win_handle;
 	RefreshWindowBounds();
 	/* TODO: Restore context */
@@ -193,7 +195,7 @@ static void JNICALL java_onLowMemory(JNIEnv* env, jobject o) {
 	/* TODO: Low memory */
 }
 
-static const JNINativeMethod methods[19] = {
+static const JNINativeMethod methods[] = {
 	{ "processKeyDown",   "(I)V", java_processKeyDown },
 	{ "processKeyUp",     "(I)V", java_processKeyUp },
 	{ "processKeyChar",   "(I)V", java_processKeyChar },
@@ -233,14 +235,7 @@ void Window_Init(void) {
 	DisplayInfo.ScaleY = JavaCallFloat(env, "getDpiY", "()F", NULL);
 }
 
-void Window_Create(int width, int height) {
-	WindowInfo.Exists = true;
-	/* actual window creation is done when processSurfaceCreated is received */
-}
-
-static cc_bool winCreated;
-static void OnWindowCreated(void* obj) { winCreated = true; }
-cc_bool Window_RemakeSurface(void) {
+static void Window_RemakeSurface(void) {
 	JNIEnv* env;
 	JavaGetCurrentEnv(env);
 	winCreated = false;
@@ -248,18 +243,23 @@ cc_bool Window_RemakeSurface(void) {
 	/* Force window to be destroyed and re-created */
 	/* (see comments in setupForGame for why this has to be done) */
 	JavaCallVoid(env, "setupForGame", "()V", NULL);
-	Event_Register_(&WindowEvents.Created, NULL, OnWindowCreated);
 	Platform_LogConst("Entering wait for window exist loop..");
 
 	/* Loop until window gets created by main UI thread */
-	while (WindowInfo.Exists && !winCreated) {
+	while (!winCreated) {
 		Window_ProcessEvents();
 		Thread_Sleep(10);
 	}
 
 	Platform_LogConst("OK window created..");
-	Event_Unregister_(&WindowEvents.Created, NULL, OnWindowCreated);
-	return winCreated;
+}
+
+void Window_Create(int width, int height) {
+	WindowInfo.Exists = true;
+	/* actual window creation is done when processSurfaceCreated is received */
+	Window_RemakeSurface();
+	/* always start as fullscreen */
+	Window_EnterFullscrene();
 }
 
 void Window_SetTitle(const cc_string* title) {

--- a/src/Window_Android.c
+++ b/src/Window_Android.c
@@ -254,13 +254,15 @@ static void Window_RemakeSurface(void) {
 	Platform_LogConst("OK window created..");
 }
 
-void Window_Create(int width, int height) {
+static void DoCreateWindow(void) {
 	WindowInfo.Exists = true;
 	/* actual window creation is done when processSurfaceCreated is received */
 	Window_RemakeSurface();
 	/* always start as fullscreen */
 	Window_EnterFullscrene();
 }
+void Window_Create2D(int width, int height) { DoCreateWindow(); }
+void Window_Create3D(int width, int height) { DoCreateWindow(); }
 
 void Window_SetTitle(const cc_string* title) {
 	/* TODO: Implement this somehow */

--- a/src/Window_Carbon.c
+++ b/src/Window_Carbon.c
@@ -479,7 +479,7 @@ static void ApplyIcon(void) {
 static void ApplyIcon(void) { }
 #endif
 
-void Window_Create(int width, int height) {
+static void DoCreateWindow(int width, int height) {
 	Rect r;
 	OSStatus res;
 	ProcessSerialNumber psn;
@@ -507,6 +507,8 @@ void Window_Create(int width, int height) {
 	winId = GetNativeWindowFromWindowRef(win_handle);
 	ApplyIcon();
 }
+void Window_Create2D(int width, int height) { DoCreateWindow(width, height); }
+void Window_Create3D(int width, int height) { DoCreateWindow(width, height); }
 
 void Window_SetTitle(const cc_string* title) {
 	UInt8 str[NATIVE_STR_LEN];

--- a/src/Window_SDL.c
+++ b/src/Window_SDL.c
@@ -35,18 +35,19 @@ void Window_Init(void) {
 	DisplayInfo.ScaleY = 1;
 }
 
-void Window_Create(int width, int height) {
+static void DoCreateWindow(int width, int height, int flags) {
 	int x = Display_CentreX(width);
 	int y = Display_CentreY(height);
 
-	/* TODO: Don't set this flag for launcher window */
-	win_handle = SDL_CreateWindow(NULL, x, y, width, height, SDL_WINDOW_OPENGL);
+	win_handle = SDL_CreateWindow(NULL, x, y, width, height, flags);
 	if (!win_handle) Window_SDLFail("creating window");
 
 	RefreshWindowBounds();
 	WindowInfo.Exists = true;
 	WindowInfo.Handle = win_handle;
 }
+void Window_Create2D(int width, int height) { DoCreateWindow(width, height, 0); }
+void Window_Create3D(int width, int height) { DoCreateWindow(width, height, SDL_WINDOW_OPENGL); }
 
 void Window_SetTitle(const cc_string* title) {
 	char str[NATIVE_STR_LEN];

--- a/src/Window_Web.c
+++ b/src/Window_Web.c
@@ -376,7 +376,7 @@ void Window_Init(void) {
 }
 
 extern void interop_InitContainer(void);
-void Window_Create(int width, int height) {
+static void DoCreateWindow(void) {
 	WindowInfo.Exists  = true;
 	WindowInfo.Focused = true;
 	HookEvents();
@@ -385,6 +385,8 @@ void Window_Create(int width, int height) {
 	WindowInfo.Height = interop_CanvasHeight();
 	interop_InitContainer();
 }
+void Window_Create2D(int width, int height) { DoCreateWindow(); }
+void Window_Create3D(int width, int height) { DoCreateWindow(); }
 
 extern void interop_SetPageTitle(const char* title);
 void Window_SetTitle(const cc_string* title) {

--- a/src/Window_Win.c
+++ b/src/Window_Win.c
@@ -285,7 +285,7 @@ static ATOM DoRegisterClass(void) {
 	return RegisterClassExA((const WNDCLASSEXA*)&wc);
 }
 
-static void DoCreateWindow(ATOM atom, int width, int height) {
+static void CreateWindowHandle(ATOM atom, int width, int height) {
 	cc_result res;
 	RECT r;
 	/* Calculate final window rectangle after window decorations are added (titlebar, borders etc) */
@@ -307,7 +307,7 @@ static void DoCreateWindow(ATOM atom, int width, int height) {
 	Logger_Abort2(res, "Failed to create window");
 }
 
-void Window_Create(int width, int height) {
+static void DoCreateWindow(int width, int height) {
 	ATOM atom;
 	win_instance = GetModuleHandleA(NULL);
 	/* TODO: UngroupFromTaskbar(); */
@@ -315,7 +315,7 @@ void Window_Create(int width, int height) {
 	height = Display_ScaleY(height);
 
 	atom = DoRegisterClass();
-	DoCreateWindow(atom, width, height);
+	CreateWindowHandle(atom, width, height);
 	RefreshWindowBounds();
 
 	win_DC = GetDC(win_handle);
@@ -323,6 +323,8 @@ void Window_Create(int width, int height) {
 	WindowInfo.Exists = true;
 	WindowInfo.Handle = win_handle;
 }
+void Window_Create2D(int width, int height) { DoCreateWindow(width, height); }
+void Window_Create3D(int width, int height) { DoCreateWindow(width, height); }
 
 void Window_SetTitle(const cc_string* title) {
 	WCHAR str[NATIVE_STR_LEN];

--- a/src/Window_X11.c
+++ b/src/Window_X11.c
@@ -278,7 +278,7 @@ static void ApplyIcon(void) {
 static void ApplyIcon(void) { }
 #endif
 
-void Window_Create(int width, int height) {
+static void DoCreateWindow(int width, int height) {
 	XSetWindowAttributes attributes = { 0 };
 	XSizeHints hints = { 0 };
 	Atom protocols[2];
@@ -340,6 +340,8 @@ void Window_Create(int width, int height) {
 	XGetInputFocus(win_display, &focus, &focusRevert);
 	if (focus == win_handle) WindowInfo.Focused = true;
 }
+void Window_Create2D(int width, int height) { DoCreateWindow(width, height); }
+void Window_Create3D(int width, int height) { DoCreateWindow(width, height); }
 
 void Window_SetTitle(const cc_string* title) {
 	char str[NATIVE_STR_LEN];

--- a/src/interop_cocoa.m
+++ b/src/interop_cocoa.m
@@ -262,7 +262,7 @@ static void ApplyIcon(void) { }
 #endif
 
 #define WIN_MASK (NSTitledWindowMask | NSClosableWindowMask | NSResizableWindowMask | NSMiniaturizableWindowMask)
-static void DoCreateWindow(void) {
+static void DoCreateWindow(int width, int height) {
 	CCWindowDelegate* del;
 	NSRect rect;
 

--- a/src/interop_cocoa.m
+++ b/src/interop_cocoa.m
@@ -262,7 +262,7 @@ static void ApplyIcon(void) { }
 #endif
 
 #define WIN_MASK (NSTitledWindowMask | NSClosableWindowMask | NSResizableWindowMask | NSMiniaturizableWindowMask)
-void Window_Create(int width, int height) {
+static void DoCreateWindow(void) {
 	CCWindowDelegate* del;
 	NSRect rect;
 
@@ -287,6 +287,8 @@ void Window_Create(int width, int height) {
 	MakeContentView();
 	ApplyIcon();
 }
+void Window_Create2D(int width, int height) { DoCreateWindow(width, height); }
+void Window_Create3D(int width, int height) { DoCreateWindow(width, height); }
 
 void Window_SetTitle(const cc_string* title) {
 	char raw[NATIVE_STR_LEN];

--- a/src/interop_ios.m
+++ b/src/interop_ios.m
@@ -123,7 +123,7 @@ void Window_Init(void) {
     DisplayInfo.ScaleY = 1; // TODO dpi scale
 }
 
-void Window_Create(int width, int height) {
+static void DoCreateWindow(void) {
     CGRect bounds = UIScreen.mainScreen.bounds;
     controller = [CCViewController alloc];
     winHandle  = [[CCWindow alloc] initWithFrame:bounds];
@@ -134,6 +134,8 @@ void Window_Create(int width, int height) {
     WindowInfo.Width  = bounds.size.width;
     WindowInfo.Height = bounds.size.height;
 }
+void Window_Create2D(int width, int height) { DoCreateWindow(); }
+void Window_Create3D(int width, int height) { DoCreateWindow(); }
 void Window_SetSize(int width, int height) { }
 
 void Window_Close(void) { }


### PR DESCRIPTION
1. Simplifies launcher/game loop on Android (Fixes #893)
2. Might fix game never working again after Android activity is destroyed and then later created again (untested)
3. Splits window creation into 2D and 3D window creation (necessary for iOS, also opens possibility of #787)

Required testing
- [x] macOS 32 bit
- [x] macOS 64 bit
- [x] Linux
- [x] SDL
- [ ] Android
- [x] Windows
- [x] Webclient