### PR TITLE
Change webclient to run in very low performance mode when tab is moved to background

### DIFF
--- a/src/Entity.c
+++ b/src/Entity.c
@@ -859,6 +859,8 @@ static void LocalPlayer_Tick(struct Entity* e, double delta) {
 	wasOnGround    = e->OnGround;
 
 	LocalInterpComp_AdvanceState(&p->Interp);
+	p->Base.Position = p->Interp.Next.Pos;
+
 	LocalPlayer_HandleInput(&xMoving, &zMoving);
 	hacks->Floating = hacks->Noclip || hacks->Flying;
 	if (!hacks->Floating && hacks->CanBePushed) PhysicsComp_DoEntityPush(e);
@@ -1134,8 +1136,10 @@ static void NetPlayer_SetLocation(struct Entity* e, struct LocationUpdate* updat
 
 static void NetPlayer_Tick(struct Entity* e, double delta) {
 	struct NetPlayer* p = (struct NetPlayer*)e;
-	Entity_CheckSkin(e);
 	NetInterpComp_AdvanceState(&p->Interp);
+	p->Base.Position = p->Interp.Next.Pos;
+
+	Entity_CheckSkin(e);
 	AnimatedComp_Update(e, p->Interp.Prev.Pos, p->Interp.Next.Pos, delta);
 }
 

--- a/src/Entity.c
+++ b/src/Entity.c
@@ -859,7 +859,7 @@ static void LocalPlayer_Tick(struct Entity* e, double delta) {
 	wasOnGround    = e->OnGround;
 
 	LocalInterpComp_AdvanceState(&p->Interp);
-	p->Base.Position = p->Interp.Next.Pos;
+	p->Base.Position = p->Interp.Prev.Pos;
 
 	LocalPlayer_HandleInput(&xMoving, &zMoving);
 	hacks->Floating = hacks->Noclip || hacks->Flying;
@@ -1137,7 +1137,7 @@ static void NetPlayer_SetLocation(struct Entity* e, struct LocationUpdate* updat
 static void NetPlayer_Tick(struct Entity* e, double delta) {
 	struct NetPlayer* p = (struct NetPlayer*)e;
 	NetInterpComp_AdvanceState(&p->Interp);
-	p->Base.Position = p->Interp.Next.Pos;
+	p->Base.Position = p->Interp.Prev.Pos;
 
 	Entity_CheckSkin(e);
 	AnimatedComp_Update(e, p->Interp.Prev.Pos, p->Interp.Next.Pos, delta);

--- a/src/EntityComponents.c
+++ b/src/EntityComponents.c
@@ -446,9 +446,7 @@ void LocalInterpComp_SetLocation(struct InterpComp* interp, struct LocationUpdat
 }
 
 void LocalInterpComp_AdvanceState(struct InterpComp* interp) {
-	struct Entity* p = &LocalPlayer_Instance.Base;
 	interp->Prev = interp->Next;
-	p->Position  = interp->Next.Pos;
 	InterpComp_AdvanceRotY(interp);
 }
 

--- a/src/Event.c
+++ b/src/Event.c
@@ -1,6 +1,7 @@
 #include "Event.h"
 #include "Logger.h"
 
+int EventAPIVersion = 1;
 struct _EntityEventsList        EntityEvents;
 struct _TabListEventsList       TabListEvents;
 struct _TextureEventsList       TextureEvents;
@@ -13,7 +14,6 @@ struct _WindowEventsList        WindowEvents;
 struct _InputEventsList         InputEvents;
 struct _PointerEventsList       PointerEvents;
 struct _NetEventsList           NetEvents;
-struct _PluginMessageEventsList PluginMessageEvents;
 
 void Event_Register(struct Event_Void* handlers, void* obj, Event_Void_Callback handler) {
 	int i;
@@ -52,7 +52,7 @@ void Event_Unregister(struct Event_Void* handlers, void* obj, Event_Void_Callbac
 }
 
 void Event_UnregisterAll(void) {
-	/* NOTE: This must be kept in sync with Event.h list of events */
+	/* NOTE: This MUST be kept in sync with Event.h list of events */
 	EntityEvents.Added.Count   = 0;
 	EntityEvents.Removed.Count = 0;
 
@@ -92,7 +92,8 @@ void Event_UnregisterAll(void) {
 	WindowEvents.Closing.Count = 0;
 	WindowEvents.FocusChanged.Count = 0;
 	WindowEvents.StateChanged.Count = 0;
-	WindowEvents.Created.Count = 0;
+	WindowEvents.Created.Count      = 0;
+	WindowEvents.InactiveChanged.Count = 0;
 
 	InputEvents.Press.Count = 0;
 	InputEvents.Down.Count  = 0;
@@ -107,6 +108,7 @@ void Event_UnregisterAll(void) {
 
 	NetEvents.Connected.Count    = 0;
 	NetEvents.Disconnected.Count = 0;
+	NetEvents.PluginMessageReceived.Count = 0;
 }
 
 void Event_RaiseVoid(struct Event_Void* handlers) {

--- a/src/Event.h
+++ b/src/Event.h
@@ -105,7 +105,14 @@ void Event_RaiseRawMove(struct Event_RawMove* handlers, float xDelta, float yDel
 void Event_RaisePluginMessage(struct Event_PluginMessage* handlers, cc_uint8 channel, cc_uint8* data);
 
 void Event_UnregisterAll(void);
-/* NOTE: Event_UnregisterAll must be updated if events lists are changed */
+/* NOTE: Event_UnregisterAll MUST be updated when events lists are changed */
+
+/* Event API version supported by the client */
+/*  Version 1 - Added NetEvents.PluginMessageReceived, */
+/* You MUST CHECK the event API version before attempting to use the events listed above, */
+/*  as otherwise if the player is using an older client that lacks some of the above events, */
+/*  you will be calling Event_Register on random data instead of the expected EventsList struct */
+CC_VAR extern int EventAPIVersion;
 
 CC_VAR extern struct _EntityEventsList {
 	struct Event_Int Added;    /* Entity is spawned in the current world */
@@ -163,8 +170,9 @@ CC_VAR extern struct _WindowEventsList {
 	struct Event_Void Resized;      /* Window is resized */
 	struct Event_Void Closing;      /* Window is about to close (should free resources/save state/etc here) */
 	struct Event_Void FocusChanged; /* Focus of the window changed */
-	struct Event_Void StateChanged; /* WindowState of the window changed */
+	struct Event_Void StateChanged; /* State of the window changed (e.g. minimised, fullscreen) */
 	struct Event_Void Created;      /* Window has been created, Window_Handle is valid now. */
+	struct Event_Void InactiveChanged; /* Inactive/background state of the window changed */
 } WindowEvents;
 
 CC_VAR extern struct _InputEventsList {
@@ -183,11 +191,8 @@ CC_VAR extern struct _PointerEventsList {
 } PointerEvents;
 
 CC_VAR extern struct _NetEventsList {
-	struct Event_Void Connected;    /* Connection to a server was established. */
-	struct Event_Void Disconnected; /* Connection to the server was lost. */
+	struct Event_Void Connected;    /* Connection to a server was established */
+	struct Event_Void Disconnected; /* Connection to the server was lost */
+	struct Event_PluginMessage PluginMessageReceived; /* Received a PluginMessage packet from the server */
 } NetEvents;
-
-CC_VAR extern struct _PluginMessageEventsList {
-	struct Event_PluginMessage Received; /* Received a PluginMessage from the server. */
-} PluginMessageEvents;
 #endif

--- a/src/Game.c
+++ b/src/Game.c
@@ -275,12 +275,17 @@ static void HandleLowVRAMDetected(void* obj) {
 
 static void HandleInactiveChanged(void* obj) {
 	if (WindowInfo.Inactive) {
-		Chat_AddRaw("&cHIDE");
+		Chat_AddRaw(LOWPERF_ENTER_MESSAGE);
 		Gfx_SetFpsLimit(false, 1000 / 1.0f);
 	} else {
-		Chat_AddRaw("&aSHOW");
+		Chat_AddRaw(LOWPERF_EXIT_MESSAGE);
 		Game_SetFpsLimit(Game_FpsLimit);
 	}
+
+#ifdef CC_BUILD_WEB
+	extern void emscripten_resume_main_loop(void);
+	emscripten_resume_main_loop();
+#endif
 }
 
 static void Game_WarnFunc(const cc_string* msg) {

--- a/src/Game.c
+++ b/src/Game.c
@@ -273,6 +273,16 @@ static void HandleLowVRAMDetected(void* obj) {
 	Chat_AddRaw("&cOut of VRAM! Halving view distance..");
 }
 
+static void HandleInactiveChanged(void* obj) {
+	if (WindowInfo.Inactive) {
+		Chat_AddRaw("&cHIDE");
+		Gfx_SetFpsLimit(false, 1000 / 1.0f);
+	} else {
+		Chat_AddRaw("&aSHOW");
+		Game_SetFpsLimit(Game_FpsLimit);
+	}
+}
+
 static void Game_WarnFunc(const cc_string* msg) {
 	cc_string str = *msg, line;
 	while (str.length) {
@@ -356,11 +366,12 @@ static void Game_Load(void) {
 	LoadOptions();
 	Utils_EnsureDirectory("maps");
 
-	Event_Register_(&WorldEvents.NewMap,        NULL, HandleOnNewMap);
-	Event_Register_(&WorldEvents.MapLoaded,     NULL, HandleOnNewMapLoaded);
-	Event_Register_(&GfxEvents.LowVRAMDetected, NULL, HandleLowVRAMDetected);
-	Event_Register_(&WindowEvents.Resized,      NULL, Game_OnResize);
-	Event_Register_(&WindowEvents.Closing,      NULL, Game_Free);
+	Event_Register_(&WorldEvents.NewMap,           NULL, HandleOnNewMap);
+	Event_Register_(&WorldEvents.MapLoaded,        NULL, HandleOnNewMapLoaded);
+	Event_Register_(&GfxEvents.LowVRAMDetected,    NULL, HandleLowVRAMDetected);
+	Event_Register_(&WindowEvents.Resized,         NULL, Game_OnResize);
+	Event_Register_(&WindowEvents.Closing,         NULL, Game_Free);
+	Event_Register_(&WindowEvents.InactiveChanged, NULL, HandleInactiveChanged);
 
 	Game_AddComponent(&World_Component);
 	Game_AddComponent(&Textures_Component);
@@ -570,11 +581,14 @@ static void Game_RenderFrame(double delta) {
 	Camera.CurrentPos = Camera.Active->GetPosition(t);
 	/* NOTE: EnvRenderer_UpdateFog also also sets clear color */
 	EnvRenderer_UpdateFog();
-	Gfx_Clear();
 	UpdateViewMatrix();
 
+	/* TODO: Not calling Gfx_EndFrame doesn't work with Direct3D9 */
+	if (WindowInfo.Inactive) return;
+	Gfx_Clear();
+
 	Gfx_LoadMatrix(MATRIX_PROJECTION, &Gfx.Projection);
-	Gfx_LoadMatrix(MATRIX_VIEW, &Gfx.View);
+	Gfx_LoadMatrix(MATRIX_VIEW,       &Gfx.View);
 
 	if (!Gui_GetBlocksWorld()) {
 		Game_Render3D(delta, t);

--- a/src/Graphics.h
+++ b/src/Graphics.h
@@ -60,6 +60,9 @@ extern GfxResourceID Gfx_quadVb, Gfx_texVb;
 /* Texture should allow updating via Gfx_UpdateTexture */
 #define TEXTURE_FLAG_DYNAMIC 0x02
 
+#define LOWPERF_ENTER_MESSAGE "&eEntering reduced performance mode (game minimised or hidden)"
+#define LOWPERF_EXIT_MESSAGE  "&eExited reduced performance mode"
+
 void Gfx_RecreateDynamicVb(GfxResourceID* vb, VertexFormat fmt, int maxVertices);
 void Gfx_RecreateTexture(GfxResourceID* tex, struct Bitmap* bmp, cc_uint8 flags, cc_bool mipmaps);
 void* Gfx_RecreateAndLockVb(GfxResourceID* vb, VertexFormat fmt, int count);

--- a/src/Protocol.c
+++ b/src/Protocol.c
@@ -1549,7 +1549,7 @@ static void CPE_UndefineModel(cc_uint8* data) {
 
 static void CPE_PluginMessage(cc_uint8* data) {
 	cc_uint8 channel = data[0];
-	Event_RaisePluginMessage(&PluginMessageEvents.Received, channel, data + 1);
+	Event_RaisePluginMessage(&NetEvents.PluginMessageReceived, channel, data + 1);
 }
 
 static void CPE_Reset(void) {

--- a/src/Window.h
+++ b/src/Window.h
@@ -75,6 +75,9 @@ CC_VAR extern struct _WinData {
 	cc_bool Focused;
 	/* The type of on-screen keyboard this platform supports. (usually SOFT_KEYBOARD_NONE) */
 	cc_uint8 SoftKeyboard;
+	/* Whether this window is backgrounded / inactivated */
+	/* (rendering is not performed when window is inactive) */
+	cc_bool Inactive;
 } WindowInfo;
 
 /* Initialises state for window. Also sets Display_ members. */

--- a/src/Window_Web.c
+++ b/src/Window_Web.c
@@ -154,16 +154,16 @@ static EM_BOOL OnFocus(int type, const EmscriptenFocusEvent* ev, void* data) {
 	return true;
 }
 
-static EM_BOOL OnResize(int type, const EmscriptenUiEvent* ev, void *data) {
+static EM_BOOL OnResize(int type, const EmscriptenUiEvent* ev, void* data) {
 	UpdateWindowBounds(); needResize = true;
 	return true;
 }
 /* This is only raised when going into fullscreen */
-static EM_BOOL OnCanvasResize(int type, const void* reserved, void *data) {
+static EM_BOOL OnCanvasResize(int type, const void* reserved, void* data) {
 	UpdateWindowBounds(); needResize = true;
 	return false;
 }
-static EM_BOOL OnFullscreenChange(int type, const EmscriptenFullscreenChangeEvent* ev, void *data) {
+static EM_BOOL OnFullscreenChange(int type, const EmscriptenFullscreenChangeEvent* ev, void* data) {
 	UpdateWindowBounds(); needResize = true;
 	return false;
 }
@@ -177,6 +177,15 @@ static const char* OnBeforeUnload(int type, const void* ev, void *data) {
 	}
 	Window_Close();
 	return NULL;
+}
+
+static EM_BOOL OnVisibilityChanged(int eventType, const EmscriptenVisibilityChangeEvent* ev, void* data) {
+	cc_bool inactive = ev->visibilityState == EMSCRIPTEN_VISIBILITY_HIDDEN;
+	if (WindowInfo.Inactive == inactive) return false;
+
+	WindowInfo.Inactive = inactive;
+	Event_RaiseVoid(&WindowEvents.InactiveChanged);
+	return false;
 }
 
 static int MapNativeKey(int k, int l) {
@@ -312,6 +321,7 @@ static void HookEvents(void) {
 	emscripten_set_blur_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,   NULL, 0, OnFocus);
 	emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, 0, OnResize);
 	emscripten_set_beforeunload_callback(                          NULL,    OnBeforeUnload);
+	emscripten_set_visibilitychange_callback(                      NULL, 0, OnVisibilityChanged);
 
 	emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,  NULL, 0, OnKeyDown);
 	emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,    NULL, 0, OnKeyUp);
@@ -333,6 +343,7 @@ static void UnhookEvents(void) {
 	emscripten_set_blur_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,   NULL, 0, NULL);
 	emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, 0, NULL);
 	emscripten_set_beforeunload_callback(                          NULL,    NULL);
+	emscripten_set_visibilitychange_callback(                      NULL, 0, NULL);
 
 	emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,  NULL, 0, NULL);
 	emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,    NULL, 0, NULL);

--- a/src/_GraphicsBase.h
+++ b/src/_GraphicsBase.h
@@ -116,13 +116,13 @@ static void TickReducedPerformance(void) {
 
 	if (reducedPerformance) return;
 	reducedPerformance = true;
-	Chat_AddRaw("&eEntering reduced performance mode (game minimised or hidden)");
+	Chat_AddRaw(LOWPERF_ENTER_MESSAGE);
 }
 
 static void EndReducedPerformance(void) {
 	if (!reducedPerformance) return;
 	reducedPerformance = false;
-	Chat_AddRaw("&eExited reduced performance mode");
+	Chat_AddRaw(LOWPERF_EXIT_MESSAGE);
 }
 
 


### PR DESCRIPTION
This essentially makes the webclient run at 1 FPS when the tab is inactive/background (instead of being completely suspended because `requestAnimationFrame` is not called when tab is in background - see https://stackoverflow.com/questions/15871942/how-do-browsers-pause-change-javascript-when-tab-or-window-is-not-active)

In very low performance method
* No rendering is performed
* Scheduled tasks are still slowly ticked (e.g. processing server packets)
* The player still moves/can be moved/can be pushed (slowly)

Required testing
* [x] Chrome
* [x] Edge
* [x] Firefox
* [x] Internet Explorer
* [x] Safari
* [x] Chrome for android
* [x] Firefox for android
* [x] Safari for iOS