### PR TITLE
Add support for loading maps through native open file dialog

### DIFF
--- a/src/EnvRenderer.c
+++ b/src/EnvRenderer.c
@@ -21,7 +21,6 @@
 
 cc_bool EnvRenderer_Legacy, EnvRenderer_Minimal;
 
-#define ENV_SMALL_VERTICES 4096
 static float CalcBlendFactor(float x) {
 	/* return -0.05 + 0.22 * (Math_Log(x) * 0.25f); */
 	double blend = -0.13 + 0.28 * (Math_Log(x) * 0.25);

--- a/src/Menus.c
+++ b/src/Menus.c
@@ -384,7 +384,7 @@ static void ListScreen_ContextRecreated(void* screen) {
 	ListScreen_UpdatePage(s);
 
 	if (!s->UploadClick) return;
-	ButtonWidget_SetConst(&s->upload, "Upload", &s->font);
+	ButtonWidget_SetConst(&s->upload, Input_TouchMode ? "Upload" : "Load file...", &s->font);
 }
 
 static void ListScreen_Reload(struct ListScreen* s) {
@@ -1764,14 +1764,12 @@ static void LoadLevelScreen_LoadEntries(struct ListScreen* s) {
 	StringsBuffer_Sort(&s->entries);
 }
 
-#ifdef CC_BUILD_WEB
 static void LoadLevelScreen_UploadCallback(const cc_string* path) { Map_LoadFrom(path); }
 static void LoadLevelScreen_UploadFunc(void* s, void* w) {
-	Window_OpenFileDialog(".cw", LoadLevelScreen_UploadCallback);
+	Platform_LogConst("UPLOAD");
+	cc_result res = Window_OpenFileDialog(".cw", LoadLevelScreen_UploadCallback);
+	if (res) Logger_SimpleWarn(res, "showing open file dialog");
 }
-#else
-#define LoadLevelScreen_UploadFunc NULL
-#endif
 
 void LoadLevelScreen_Show(void) {
 	struct ListScreen* s = &ListScreen;

--- a/src/Menus.c
+++ b/src/Menus.c
@@ -201,16 +201,18 @@ static struct Widget* list_widgets[10] = {
 static void ListScreen_Layout(void* screen) {
 	struct ListScreen* s = (struct ListScreen*)screen;
 	int i;
+
 	for (i = 0; i < LIST_SCREEN_ITEMS; i++) { 
 		Widget_SetLocation(&s->btns[i],
 			ANCHOR_CENTRE, ANCHOR_CENTRE, 0, (i - 2) * 50);
 	}
 
-	if (s->UploadClick) {
+	if (s->UploadClick && Input_TouchMode) {
 		Widget_SetLocation(&s->done,   ANCHOR_CENTRE_MIN, ANCHOR_MAX, -150, 25);
 		Widget_SetLocation(&s->upload, ANCHOR_CENTRE_MAX, ANCHOR_MAX, -150, 25);
 	} else {
-		Menu_LayoutBack(&s->done);
+		Widget_SetLocation(&s->done,   ANCHOR_CENTRE, ANCHOR_MAX, 0, 25);
+		Widget_SetLocation(&s->upload, ANCHOR_CENTRE, ANCHOR_MAX, 0, 70);
 	}
 
 	Widget_SetLocation(&s->left,  ANCHOR_CENTRE, ANCHOR_CENTRE, -220,    0);
@@ -384,7 +386,11 @@ static void ListScreen_ContextRecreated(void* screen) {
 	ListScreen_UpdatePage(s);
 
 	if (!s->UploadClick) return;
-	ButtonWidget_SetConst(&s->upload, Input_TouchMode ? "Upload" : "Load file...", &s->font);
+#ifdef CC_BUILD_WEB
+	ButtonWidget_SetConst(&s->upload, "Upload", &s->font);
+#else
+	ButtonWidget_SetConst(&s->upload, "Load file...", &s->font);
+#endif
 }
 
 static void ListScreen_Reload(struct ListScreen* s) {

--- a/src/Menus.c
+++ b/src/Menus.c
@@ -1587,7 +1587,8 @@ static void TexturePackScreen_UploadCallback(const cc_string* path) {
 }
 
 static void TexturePackScreen_UploadFunc(void* s, void* w) {
-	Window_OpenFileDialog(".zip", TexturePackScreen_UploadCallback);
+	static const char* const filters[] = { ".zip", NULL };
+	Window_OpenFileDialog(filters, TexturePackScreen_UploadCallback);
 }
 #else
 #define TexturePackScreen_UploadFunc NULL
@@ -1766,8 +1767,10 @@ static void LoadLevelScreen_LoadEntries(struct ListScreen* s) {
 
 static void LoadLevelScreen_UploadCallback(const cc_string* path) { Map_LoadFrom(path); }
 static void LoadLevelScreen_UploadFunc(void* s, void* w) {
-	Platform_LogConst("UPLOAD");
-	cc_result res = Window_OpenFileDialog(".cw", LoadLevelScreen_UploadCallback);
+	static const char* const filters[] = { 
+		".cw", ".dat", ".lvl", ".mine", ".fcm", NULL 
+	};
+	cc_result res = Window_OpenFileDialog(filters, LoadLevelScreen_UploadCallback);
 	if (res) Logger_SimpleWarn(res, "showing open file dialog");
 }
 

--- a/src/Window.h
+++ b/src/Window.h
@@ -133,7 +133,7 @@ void Cursor_SetVisible(cc_bool visible);
 CC_API void Window_ShowDialog(const char* title, const char* msg);
 typedef void (*OpenFileDialogCallback)(const cc_string* path);
 /* Shows an 'load file' dialog window. */
-cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback);
+cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback);
 
 /* Allocates a framebuffer that can be drawn/transferred to the window. */
 /* NOTE: Do NOT free bmp->Scan0, use Window_FreeFramebuffer. */

--- a/src/Window_Android.c
+++ b/src/Window_Android.c
@@ -363,6 +363,10 @@ static void ShowDialogCore(const char* title, const char* msg) {
 	(*env)->DeleteLocalRef(env, args[1].l);
 }
 
+cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+	return ERR_NOT_SUPPORTED;
+}
+
 static struct Bitmap fb_bmp;
 void Window_AllocFramebuffer(struct Bitmap* bmp) {
 	bmp->scan0 = (BitmapCol*)Mem_Alloc(bmp->width * bmp->height, 4, "window pixels");

--- a/src/Window_Android.c
+++ b/src/Window_Android.c
@@ -363,7 +363,7 @@ static void ShowDialogCore(const char* title, const char* msg) {
 	(*env)->DeleteLocalRef(env, args[1].l);
 }
 
-cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback) {
 	return ERR_NOT_SUPPORTED;
 }
 

--- a/src/Window_Carbon.c
+++ b/src/Window_Carbon.c
@@ -607,6 +607,10 @@ static void ShowDialogCore(const char* title, const char* msg) {
 	showingDialog = false;
 }
 
+cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+	return ERR_NOT_SUPPORTED;
+}
+
 static CGrafPtr fb_port;
 static struct Bitmap fb_bmp;
 static CGColorSpaceRef colorSpace;

--- a/src/Window_Carbon.c
+++ b/src/Window_Carbon.c
@@ -607,7 +607,7 @@ static void ShowDialogCore(const char* title, const char* msg) {
 	showingDialog = false;
 }
 
-cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback) {
 	return ERR_NOT_SUPPORTED;
 }
 

--- a/src/Window_SDL.c
+++ b/src/Window_SDL.c
@@ -272,6 +272,10 @@ static void ShowDialogCore(const char* title, const char* msg) {
 	SDL_ShowSimpleMessageBox(0, title, msg, win_handle);
 }
 
+cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+	return ERR_NOT_SUPPORTED;
+}
+
 static SDL_Surface* surface;
 void Window_AllocFramebuffer(struct Bitmap* bmp) {
 	surface = SDL_GetWindowSurface(win_handle);

--- a/src/Window_SDL.c
+++ b/src/Window_SDL.c
@@ -272,7 +272,7 @@ static void ShowDialogCore(const char* title, const char* msg) {
 	SDL_ShowSimpleMessageBox(0, title, msg, win_handle);
 }
 
-cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback) {
 	return ERR_NOT_SUPPORTED;
 }
 

--- a/src/Window_Web.c
+++ b/src/Window_Web.c
@@ -549,7 +549,7 @@ cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callb
 	uploadCallback = callback;
 	/* Calls Window_OnFileUploaded on success */
 	interop_OpenFileDialog(filter);
-	return ERR_NOT_SUPPORTED;
+	return 0;
 }
 
 void Window_AllocFramebuffer(struct Bitmap* bmp) { }

--- a/src/Window_Web.c
+++ b/src/Window_Web.c
@@ -545,7 +545,20 @@ EMSCRIPTEN_KEEPALIVE void Window_OnFileUploaded(const char* src) {
 }
 
 extern void interop_OpenFileDialog(const char* filter);
-cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback) {
+	cc_string path; char pathBuffer[NATIVE_STR_LEN];
+	char filter[NATIVE_STR_LEN];
+	int i;
+
+	/* Filter tokens are , separated - e.g. ".cw,.dat */
+	String_InitArray(path, pathBuffer);
+	for (i = 0; filters[i]; i++)
+	{
+		if (i) String_Append(&path, ',');
+		String_AppendConst(&path, filters[i]);
+	}
+	Platform_EncodeUtf8(filter, &path);
+
 	uploadCallback = callback;
 	/* Calls Window_OnFileUploaded on success */
 	interop_OpenFileDialog(filter);

--- a/src/Window_X11.c
+++ b/src/Window_X11.c
@@ -966,6 +966,10 @@ static void ShowDialogCore(const char* title, const char* msg) {
 	XFlush(m.dpy); /* flush so window disappears immediately */
 }
 
+cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+	return ERR_NOT_SUPPORTED;
+}
+
 static GC fb_gc;
 static XImage* fb_image;
 static struct Bitmap fb_bmp;

--- a/src/Window_X11.c
+++ b/src/Window_X11.c
@@ -10,6 +10,7 @@
 #include <X11/Xutil.h>
 #include <X11/XKBlib.h>
 #include <X11/extensions/XInput2.h>
+#include <stdio.h>
 
 #ifdef X_HAVE_UTF8_STRING
 #define CC_BUILD_XIM
@@ -967,7 +968,43 @@ static void ShowDialogCore(const char* title, const char* msg) {
 }
 
 cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback) {
-	return ERR_NOT_SUPPORTED;
+	cc_string path; char pathBuffer[1024];
+	char result[4096] = { 0 };
+	int len, i;
+	FILE* fp;
+
+	String_InitArray_NT(path, pathBuffer);
+	String_AppendConst(&path, "zenity --file-selection --file-filter='All supported files (");
+
+	for (i = 0; filters[i]; i++)
+	{
+		if (i) String_Append(&path, ',');
+		String_Format1(&path, "*%c", filters[i]);
+	}
+	String_AppendConst(&path, ") |");
+
+	for (i = 0; filters[i]; i++)
+	{
+		String_Format1(&path, " *%c", filters[i]);
+	}
+	String_AppendConst(&path, "'");
+	path.buffer[path.length] = '\0';
+
+	/* TODO this doesn't detect when Zenity doesn't exist */
+	fp = popen(path.buffer, "r");
+	if (!fp) return 0;
+
+	/* result is normally just one string */
+	while (fgets(result, sizeof(result), fp)) { }
+	len = String_Length(result);
+
+	if (len) {
+		String_InitArray(path, pathBuffer);
+		String_AppendUtf8(&path, result, len);
+		callback(&path);
+	}
+	pclose(fp);
+	return 0;
 }
 
 static GC fb_gc;

--- a/src/Window_X11.c
+++ b/src/Window_X11.c
@@ -966,7 +966,7 @@ static void ShowDialogCore(const char* title, const char* msg) {
 	XFlush(m.dpy); /* flush so window disappears immediately */
 }
 
-cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback) {
 	return ERR_NOT_SUPPORTED;
 }
 

--- a/src/interop_cocoa.m
+++ b/src/interop_cocoa.m
@@ -507,6 +507,10 @@ void ShowDialogCore(const char* title, const char* msg) {
 	CFRelease(msgCF);
 }
 
+cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+	return ERR_NOT_SUPPORTED;
+}
+
 static struct Bitmap fb_bmp;
 void Window_AllocFramebuffer(struct Bitmap* bmp) {
 	bmp->scan0 = (BitmapCol*)Mem_Alloc(bmp->width * bmp->height, 4, "window pixels");

--- a/src/interop_cocoa.m
+++ b/src/interop_cocoa.m
@@ -507,7 +507,7 @@ void ShowDialogCore(const char* title, const char* msg) {
 	CFRelease(msgCF);
 }
 
-cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback) {
 	return ERR_NOT_SUPPORTED;
 }
 

--- a/src/interop_ios.m
+++ b/src/interop_ios.m
@@ -260,6 +260,10 @@ void Window_LockLandscapeOrientation(cc_bool lock) {
     [UIViewController attemptRotationToDeviceOrientation];
 }
 
+cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+	return ERR_NOT_SUPPORTED;
+}
+
 
 /*#########################################################################################################################*
  *--------------------------------------------------------2D window--------------------------------------------------------*

--- a/src/interop_ios.m
+++ b/src/interop_ios.m
@@ -260,7 +260,7 @@ void Window_LockLandscapeOrientation(cc_bool lock) {
     [UIViewController attemptRotationToDeviceOrientation];
 }
 
-cc_result Window_OpenFileDialog(const char* filter, OpenFileDialogCallback callback) {
+cc_result Window_OpenFileDialog(const char* const* filters, OpenFileDialogCallback callback) {
 	return ERR_NOT_SUPPORTED;
 }
 


### PR DESCRIPTION
Supported platforms
* Webclient (Support was already there, but expanded from .cw to all map formats)
* Windows (implemented using GetOpenFileName)
* macOS 64 bit (implemented using NSOpenPanel)

Unsupported platforms
* macOS 32 bit (could maybe be done through Navigation framework, but looks like a lot of work)
* Android (attempted to but ran into number of issues)

Android issues:
1) can't figure out how to filter by file extension, only seems to support MIME types 
2) the dialog returns a content URL which cannot always easily be converted back into files (can be converted into `InputStream` so it's still possible to get the map data, but would require a lot of reworking of `Map_LoadFrom` and associated functions to not rely on determining map format from file extension..)