### PR TITLE
Fix .desktop file using $HOME as working directory

### DIFF
--- a/misc/install-desktop-entry.sh
+++ b/misc/install-desktop-entry.sh
@@ -21,6 +21,7 @@ echo "Comment=Minecraft Classic inspired sandbox game" >> $DESKTOP_FILE
 echo "Name=ClassiCube" >> $DESKTOP_FILE
 echo "Exec=$GAME_DIR/ClassiCube" >> $DESKTOP_FILE
 echo "Icon=$GAME_DIR/CCicon.png" >> $DESKTOP_FILE
+echo "Path=$GAME_DIR" >> $DESKTOP_FILE
 echo "Terminal=false" >> $DESKTOP_FILE
 echo "Categories=Game;" >> $DESKTOP_FILE
 chmod +x $DESKTOP_FILE


### PR DESCRIPTION
After bd94a9a the .desktop file generated by `install-desktop-entry.sh` stores files in $HOME instead of the game directory. This PR just specifies the working directory in the desktop entry.