### PR TITLE
More support for SerenityOS

### DIFF
--- a/src/Drawer2D.c
+++ b/src/Drawer2D.c
@@ -818,6 +818,7 @@ static cc_string font_candidates[] = {
 	String_FromConst("Cantarell"),
 	String_FromConst("DejaVu Sans Book"), 
 	String_FromConst("Century Schoolbook L Roman"), /* commonly available on linux */
+	String_FromConst("Liberation Serif"), /* for SerenityOS */
 	String_FromConst("Slate For OnePlus"), /* Android 10, some devices */
 	String_FromConst("Roboto"), /* Android (broken on some Android 10 devices) */
 	String_FromConst("Geneva"), /* for ancient macOS versions */

--- a/src/Http_Worker.c
+++ b/src/Http_Worker.c
@@ -254,6 +254,9 @@ static const cc_string curlAlt = String_FromConst("/usr/pkg/lib/libcurl.so");
 #elif defined CC_BUILD_BSD
 static const cc_string curlLib = String_FromConst("libcurl.so");
 static const cc_string curlAlt = String_FromConst("libcurl.so");
+#elif defined CC_BUILD_SERENITY
+static const cc_string curlLib = String_FromConst("/usr/local/lib/libcurl.so");
+static const cc_string curlAlt = String_FromConst("/usr/local/lib/libcurl.so");
 #else
 static const cc_string curlLib = String_FromConst("libcurl.so.4");
 static const cc_string curlAlt = String_FromConst("libcurl.so.3");

--- a/src/Logger.c
+++ b/src/Logger.c
@@ -767,6 +767,19 @@ static void PrintRegisters(cc_string* str, void* ctx) {
 	#error "Unknown CPU architecture"
 #endif
 }
+#elif defined CC_BUILD_SERENITY
+static void PrintRegisters(cc_string* str, void* ctx) {
+	mcontext_t r = ((ucontext_t*)ctx)->uc_mcontext;
+#if defined __i386__
+	#define REG_GET(reg, ign) &r.e##reg
+	Dump_X86()
+#elif defined __x86_64__
+	#define REG_GET(reg, ign) &r.r##reg
+	Dump_X64()
+#else
+	#error "Unknown CPU architecture"
+#endif
+}
 #endif
 
 static void DumpRegisters(void* ctx) {

--- a/src/Platform_Posix.c
+++ b/src/Platform_Posix.c
@@ -459,6 +459,10 @@ void Platform_LoadSysFonts(void) {
 		String_FromConst("/System/Library/Fonts"),
 		String_FromConst("/Library/Fonts")
 	};
+#elif defined CC_BUILD_SERENITY
+	static const cc_string dirs[] = {
+		String_FromConst("/res/fonts")
+	};
 #else
 	static const cc_string dirs[] = {
 		String_FromConst("/usr/share/fonts"),


### PR DESCRIPTION
Although this is still missing a few things such as backtraces, these changes should make it possible to build the SerenityOS port without needing any patches.