### PR TITLE
Add proper android content:// provider

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
   <application android:icon="@mipmap/ccicon" android:label="ClassiCube">
     <provider
         android:name="com.classicube.CCFileProvider"
-        android:authorities="com.classicube.android.client.ccfiles"
+        android:authorities="com.classicube.android.client.provider"
         android:exported="false"
         android:grantUriPermissions="true" >
     </provider>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,12 @@
   <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="26"/>
   
   <application android:icon="@mipmap/ccicon" android:label="ClassiCube">
+    <provider
+        android:name="com.classicube.CCFileProvider"
+        android:authorities="com.classicube.android.client.ccfiles"
+        android:exported="false"
+        android:grantUriPermissions="true" >
+    </provider>
 
     <activity android:name="com.classicube.MainActivity" android:label="ClassiCube"
               android:configChanges="orientation|screenSize|keyboard|keyboardHidden">

--- a/android/app/src/main/java/com/classicube/CCFileProvider.java
+++ b/android/app/src/main/java/com/classicube/CCFileProvider.java
@@ -12,11 +12,12 @@ import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
+import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 
 public class CCFileProvider extends ContentProvider
 {
-    final static String[] DEFAULT_COLUMNS = { OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE };
+    final static String[] DEFAULT_COLUMNS = { OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE, MediaStore.MediaColumns.DATA };
     File root;
 
     @Override
@@ -33,11 +34,11 @@ public class CCFileProvider extends ContentProvider
     @Override
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
         File file = getFileForUri(uri);
-        // can be null when caller is requesting all supported columns
+        // can be null when caller is requesting all columns
         if (projection == null) projection = DEFAULT_COLUMNS;
 
-        ArrayList<String> cols = new ArrayList<String>(2);
-        ArrayList<Object> vals = new ArrayList<Object>(2);
+        ArrayList<String> cols = new ArrayList<String>(3);
+        ArrayList<Object> vals = new ArrayList<Object>(3);
 
         for (String column : projection) {
             if (column.equals(OpenableColumns.DISPLAY_NAME)) {
@@ -46,6 +47,9 @@ public class CCFileProvider extends ContentProvider
             } else if (column.equals(OpenableColumns.SIZE)) {
                 cols.add(OpenableColumns.SIZE);
                 vals.add(file.length());
+            } else if (column.equals(MediaStore.MediaColumns.DATA)) {
+                cols.add(MediaStore.MediaColumns.DATA);
+                vals.add(file.getAbsolutePath());
             }
         }
 
@@ -92,7 +96,7 @@ public class CCFileProvider extends ContentProvider
         // See AndroidManifest.xml for authority
         return new Uri.Builder()
                 .scheme("content")
-                .authority("com.classicube.android.client.ccfiles")
+                .authority("com.classicube.android.client.provider")
                 .encodedPath(Uri.encode(path, "/"))
                 .build();
     }
@@ -100,7 +104,7 @@ public class CCFileProvider extends ContentProvider
     File getFileForUri(Uri uri) {
         String path = uri.getPath();
         File file   = new File(root, path);
-        
+
         file = file.getAbsoluteFile();
         // security validation check
         if (!file.getPath().startsWith(root.getPath())) {

--- a/android/app/src/main/java/com/classicube/CCFileProvider.java
+++ b/android/app/src/main/java/com/classicube/CCFileProvider.java
@@ -1,0 +1,111 @@
+package com.classicube;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.pm.ProviderInfo;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.provider.OpenableColumns;
+
+public class CCFileProvider extends ContentProvider
+{
+    final static String[] DEFAULT_COLUMNS = { OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE };
+    File root;
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public void attachInfo(Context context, ProviderInfo info) {
+        super.attachInfo(context, info);
+        root = context.getExternalFilesDir(null); // getGameDataDirectory
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        File file = getFileForUri(uri);
+        // can be null when caller is requesting all supported columns
+        if (projection == null) projection = DEFAULT_COLUMNS;
+
+        ArrayList<String> cols = new ArrayList<String>(2);
+        ArrayList<Object> vals = new ArrayList<Object>(2);
+
+        for (String column : projection) {
+            if (column.equals(OpenableColumns.DISPLAY_NAME)) {
+                cols.add(OpenableColumns.DISPLAY_NAME);
+                vals.add(file.getName());
+            } else if (column.equals(OpenableColumns.SIZE)) {
+                cols.add(OpenableColumns.SIZE);
+                vals.add(file.length());
+            }
+        }
+
+        // https://stackoverflow.com/questions/4042434/converting-arrayliststring-to-string-in-java
+        MatrixCursor cursor = new MatrixCursor(cols.toArray(new String[0]), 1);
+        cursor.addRow(vals.toArray());
+        return cursor;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        String path = uri.getEncodedPath();
+        int sepExt  = path.lastIndexOf('.');
+
+        if (sepExt >= 0) {
+            String fileExt = path.substring(sepExt);
+            if (fileExt.equals(".png")) return "image/png";
+        }
+        return "application/octet-stream";
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        throw new UnsupportedOperationException("Readonly access");
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException("Readonly access");
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException("Readonly access");
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        File file = getFileForUri(uri);
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+    }
+
+    public static Uri getUriForFile(String path) {
+        // See AndroidManifest.xml for authority
+        return new Uri.Builder()
+                .scheme("content")
+                .authority("com.classicube.android.client.ccfiles")
+                .encodedPath(Uri.encode(path, "/"))
+                .build();
+    }
+
+    File getFileForUri(Uri uri) {
+        String path = uri.getPath();
+        File file   = new File(root, path);
+        
+        file = file.getAbsoluteFile();
+        // security validation check
+        if (!file.getPath().startsWith(root.getPath())) {
+            throw new SecurityException("Resolved path lies outside app directory:" + path);
+        }
+        return file;
+    }
+}

--- a/android/app/src/main/java/com/classicube/MainActivity.java
+++ b/android/app/src/main/java/com/classicube/MainActivity.java
@@ -794,7 +794,17 @@ public class MainActivity extends Activity
 	
 	public String shareScreenshot(String path) {
 		try {
-			Uri uri = CCFileProvider.getUriForFile("screenshots", path);
+			Uri uri;
+			if (android.os.Build.VERSION.SDK_INT >= 23){ // android 6.0
+				uri = CCFileProvider.getUriForFile("screenshots/" + path);
+			} else {
+				// when trying to use content:// URIs on my android 4.0.3 test device
+				//   - 1 app crashed
+				//   - 1 app wouldn't show image previews
+				// so fallback to file:// on older devices as they seem to reliably work
+				File file = new File(getGameDataDirectory() + "/screenshots/" + path);
+				uri = Uri.fromFile(file);
+			}
 			Intent intent = new Intent();
 			
 			intent.setAction(Intent.ACTION_SEND);

--- a/android/app/src/main/java/com/classicube/MainActivity.java
+++ b/android/app/src/main/java/com/classicube/MainActivity.java
@@ -26,7 +26,6 @@ import android.database.Cursor;
 import android.graphics.PixelFormat;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.StrictMode;
 import android.provider.OpenableColumns;
 import android.provider.Settings.Secure;
 import android.text.Editable;
@@ -159,19 +158,6 @@ public class MainActivity extends Activity
 		runGameAsync();
 	}
 	
-	void HACK_avoidFileUriExposedErrors() {
-		// StrictMode - API level 9
-		// disableDeathOnFileUriExposure - API level 24 ?????
-		try {
-			Method m = StrictMode.class.getMethod("disableDeathOnFileUriExposure");
-			m.invoke(null);
-		}  catch (NoClassDefFoundError ex) {
-			ex.printStackTrace();
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
-	}
-	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		// requestWindowFeature - API level 1
@@ -192,9 +178,6 @@ public class MainActivity extends Activity
 		// Need to find a solution that both renders over display cutouts and doesn't mess up onscreen input
 		// renderOverDisplayCutouts();
 		// TODO: semaphore for destroyed and surfaceDestroyed
-
-		// avoid FileUriExposed exception when taking screenshots on recent Android versions
-		HACK_avoidFileUriExposedErrors();
 
 		if (!gameRunning) startGameAsync();
 		// TODO rethink to avoid this
@@ -811,11 +794,11 @@ public class MainActivity extends Activity
 	
 	public String shareScreenshot(String path) {
 		try {
-			File file = new File(getGameDataDirectory() + "/screenshots/" + path);
+			Uri uri = CCFileProvider.getUriForFile("screenshots", path);
 			Intent intent = new Intent();
 			
 			intent.setAction(Intent.ACTION_SEND);
-			intent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(file));
+			intent.putExtra(Intent.EXTRA_STREAM, uri);
 			intent.setType("image/png");
 			intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 			startActivity(Intent.createChooser(intent, "share via"));

--- a/misc/buildbot.sh
+++ b/misc/buildbot.sh
@@ -179,9 +179,12 @@ build_android() {
   #  https://github.com/skanti/Android-Manual-Build-Command-Line/blob/master/hello-jni/Makefile
   #  https://github.com/skanti/Android-Manual-Build-Command-Line/blob/master/hello-jni/CMakeLists.txt
   
-  # compile interop java file into its multiple .class files
-  javac java/com/classicube/MainActivity.java -d ./obj -classpath $SDK_ROOT/android.jar
+  # compile java files into multiple .class files
+  cd $ROOT_DIR/android/app/src/main/java/com/classicube
+  javac *.java -d $ROOT_DIR/android/app/src/main/obj -classpath $SDK_ROOT/android.jar
   if [ $? -ne 0 ]; then echo "Failed to compile Android Java" >> "$ERRS_FILE"; fi
+  
+  cd $ROOT_DIR/android/app/src/main
   # compile the multiple .class files into one .dex file
   $TOOLS_ROOT/dx --dex --output=obj/classes.dex ./obj
   # create initial .apk with packaged version of resources


### PR DESCRIPTION
This implements a content provider so that screenshots can be shared via a `content://` urls instead of using completely deprecated `file://` urls

Note: This doesn't work properly on my android 4.0.3 device. Don't merge until that (if?) can be fixed

This is similar to the AndroidContentProvider branch which I had worked on back in September 2020, except that I had completely forgotten that I even did that in the first place (And only realised that after I had already written all the new code..)