### PR TITLE
Fix implicit function declaration error from interop_cocoa.m on line 23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# Don't Use!
+dontuse

--- a/android/app/.cxx/ndk_locator_record.json
+++ b/android/app/.cxx/ndk_locator_record.json
@@ -1,0 +1,28 @@
+{
+  "messages": [
+    {
+      "level": "INFO",
+      "message": "android.ndkVersion from module build.gradle is not set"
+    },
+    {
+      "level": "INFO",
+      "message": "ndk.dir in local.properties is not set"
+    },
+    {
+      "level": "INFO",
+      "message": "ANDROID_NDK_HOME environment variable is not set"
+    },
+    {
+      "level": "INFO",
+      "message": "sdkFolder is not set"
+    },
+    {
+      "level": "INFO",
+      "message": "Because no explicit NDK was requested, the default version \u002720.0.5594570\u0027 for this Android Gradle Plugin will be used"
+    },
+    {
+      "level": "WARN",
+      "message": "Compatible side by side NDK version was not found. Default is 20.0.5594570."
+    }
+  ]
+}

--- a/src/interop_cocoa.h
+++ b/src/interop_cocoa.h
@@ -1,0 +1,11 @@
+#include "_WindowBase.h"
+#include "ExtMath.h"
+#include "Funcs.h"
+#include "Bitmap.h"
+#include "String.h"
+#include "Options.h"
+#include <Cocoa/Cocoa.h>
+#include <ApplicationServices/ApplicationServices.h>
+
+// asynkitty: Fixes implicit function declaration error on line 23 from interop_cocoa.m. Might be a weird hack but I don't know.
+int CGDisplayBitsPerPixel(CGDirectDisplayID display);

--- a/src/interop_cocoa.m
+++ b/src/interop_cocoa.m
@@ -1,11 +1,4 @@
-#include "_WindowBase.h"
-#include "ExtMath.h"
-#include "Funcs.h"
-#include "Bitmap.h"
-#include "String.h"
-#include "Options.h"
-#include <Cocoa/Cocoa.h>
-#include <ApplicationServices/ApplicationServices.h>
+#include "interop_cocoa.h"
 
 static int windowX, windowY;
 static NSApplication* appHandle;


### PR DESCRIPTION
This is a really simple fix for a build error I experienced while following the macOS instructions from the readme.
What it does:
- Define a prototype for the function `int CGDisplayBitsPerPixel(CGDirectDisplayID);` in a new file called `interop_cocoa.h`
- Move all includes from `interop_cocoa.m` to `interop_cocoa.h`
- Include `interop_cocoa.h` in `interop_cocoa.m`
This will fix the implicit declaration error. It does not change any code in `interop_cocoa.m` besides include statements.