### PR TITLE
Standardize some language

### DIFF
--- a/src/Animations.c
+++ b/src/Animations.c
@@ -208,29 +208,29 @@ static void Animations_ReadDescription(struct Stream* stream, const cc_string* p
 		if (!line.length || line.buffer[0] == '#') continue;
 		count = String_UNSAFE_Split(&line, ' ', parts, ANIM_MIN_ARGS);
 		if (count < ANIM_MIN_ARGS) {
-			Chat_Add1("&cNot enough arguments for anim: %s", &line); continue;
+			Chat_Add1("&cNot enough arguments for animation: %s", &line); continue;
 		}
 
 		if (!Convert_ParseUInt8(&parts[0], &tileX) || tileX >= ATLAS2D_TILES_PER_ROW) {
-			Chat_Add1("&cInvalid anim tile X coord: %s", &parts[0]); continue;
+			Chat_Add1("&cInvalid animation tile X coord: %s", &parts[0]); continue;
 		}
 		if (!Convert_ParseUInt8(&parts[1], &tileY) || tileY >= ATLAS2D_MAX_ROWS_COUNT) {
-			Chat_Add1("&cInvalid anim tile Y coord: %s", &parts[1]); continue;
+			Chat_Add1("&cInvalid animation tile Y coord: %s", &parts[1]); continue;
 		}
 		if (!Convert_ParseUInt16(&parts[2], &data.frameX)) {
-			Chat_Add1("&cInvalid anim frame X coord: %s", &parts[2]); continue;
+			Chat_Add1("&cInvalid animation frame X coord: %s", &parts[2]); continue;
 		}
 		if (!Convert_ParseUInt16(&parts[3], &data.frameY)) {
-			Chat_Add1("&cInvalid anim frame Y coord: %s", &parts[3]); continue;
+			Chat_Add1("&cInvalid animation frame Y coord: %s", &parts[3]); continue;
 		}
 		if (!Convert_ParseUInt16(&parts[4], &data.frameSize) || !data.frameSize) {
-			Chat_Add1("&cInvalid anim frame size: %s", &parts[4]); continue;
+			Chat_Add1("&cInvalid animation frame size: %s", &parts[4]); continue;
 		}
 		if (!Convert_ParseUInt16(&parts[5], &data.statesCount)) {
-			Chat_Add1("&cInvalid anim states count: %s", &parts[5]); continue;
+			Chat_Add1("&cInvalid animation states count: %s", &parts[5]); continue;
 		}
 		if (!Convert_ParseUInt16(&parts[6], &data.frameDelay)) {
-			Chat_Add1("&cInvalid anim frame delay: %s", &parts[6]); continue;
+			Chat_Add1("&cInvalid animation frame delay: %s", &parts[6]); continue;
 		}
 
 		if (anims_count == Array_Elems(anims_list)) {

--- a/src/LScreens.c
+++ b/src/LScreens.c
@@ -233,7 +233,7 @@ static void ChooseModeScreen_Init(struct LScreen* s_) {
 
 	LButton_Init(&s->btnClassic, 145, 35, "Classic",                        mode_btnClassic);
 	LLabel_Init( &s->lblClassic[0], "&eOnly uses blocks and features from", mode_lblClassic0);
-	LLabel_Init( &s->lblClassic[1], "&ethe original minecraft classic",     mode_lblClassic1);
+	LLabel_Init( &s->lblClassic[1], "&ethe original Minecraft Classic",     mode_lblClassic1);
 
 	LLabel_Init( &s->lblHelp, "&eClick &fEnhanced &eif you're not sure which mode to choose.", mode_lblHelp);
 	LButton_Init(&s->btnBack, 80, 35, "Back",                                                  mode_btnBack);

--- a/src/LScreens.c
+++ b/src/LScreens.c
@@ -563,9 +563,9 @@ static void DirectConnectScreen_Init(struct LScreen* s_) {
 	s->widgets    = directConnect_widgets;
 	s->numWidgets = Array_Elems(directConnect_widgets);
 
-	LInput_Init(&s->iptUsername, 330, "Username..",               dc_iptUsername);
-	LInput_Init(&s->iptAddress,  330, "IP address:Port number..", dc_iptAddress);
-	LInput_Init(&s->iptMppass,   330, "Mppass..",                 dc_iptMppass);
+	LInput_Init(&s->iptUsername, 330, "Username...",               dc_iptUsername);
+	LInput_Init(&s->iptAddress,  330, "IP address:Port number...", dc_iptAddress);
+	LInput_Init(&s->iptMppass,   330, "Mppass...",                 dc_iptMppass);
 
 	LButton_Init(&s->btnConnect, 110, 35, "Connect", dc_btnConnect);
 	LButton_Init(&s->btnBack,     80, 35, "Back",    dc_btnBack);
@@ -629,10 +629,10 @@ static void MFAScreen_Init(struct LScreen* s_) {
 	s->widgets    = mfa_widgets;
 	s->numWidgets = Array_Elems(mfa_widgets);
 	
-	LLabel_Init( &s->lblTitle,  "",                  mfa_lblTitle);
-	LInput_Init( &s->iptCode,   280, "Login code..", mfa_iptCode);
-	LButton_Init(&s->btnSignIn, 100, 35, "Sign in",  mfa_btnSignIn);
-	LButton_Init(&s->btnCancel, 100, 35, "Cancel",   mfa_btnCancel);
+	LLabel_Init( &s->lblTitle,  "",                   mfa_lblTitle);
+	LInput_Init( &s->iptCode,   280, "Login code...", mfa_iptCode);
+	LButton_Init(&s->btnSignIn, 100, 35, "Sign in",   mfa_btnSignIn);
+	LButton_Init(&s->btnCancel, 100, 35, "Cancel",    mfa_btnCancel);
 
 	s->btnSignIn.OnClick = MFAScreen_SignIn;
 	s->btnCancel.OnClick = MFAScreen_Cancel;
@@ -750,7 +750,7 @@ static void MainScreen_DoLogin(void) {
 	Options_SetSecure(LOPT_PASSWORD, pass);
 
 	GetTokenTask_Run();
-	LLabel_SetConst(&s->lblStatus, "&eSigning in..");
+	LLabel_SetConst(&s->lblStatus, "&eSigning in...");
 	s->signingIn = true;
 }
 static void MainScreen_Login(void* w) { MainScreen_DoLogin(); }
@@ -819,8 +819,8 @@ static void MainScreen_Init(struct LScreen* s_) {
 #endif
 	if (!Updater_Supported) s->numWidgets--;
 
-	LInput_Init( &s->iptUsername, 280, "Username..",  main_iptUsername);
-	LInput_Init( &s->iptPassword, 280, "Password..",  main_iptPassword);
+	LInput_Init( &s->iptUsername, 280, "Username...", main_iptUsername);
+	LInput_Init( &s->iptPassword, 280, "Password...", main_iptPassword);
 	LButton_Init(&s->btnLogin,    100, 35, "Sign in", main_btnLogin);
 	LButton_Init(&s->btnResume,   100, 35, "Resume",  main_btnResume);
 
@@ -828,7 +828,7 @@ static void MainScreen_Init(struct LScreen* s_) {
 	LButton_Init(&s->btnDirect,  200, 35, "Direct connect", main_btnDirect);
 	LButton_Init(&s->btnSPlayer, 200, 35, "Singleplayer",   main_btnSPlayer);
 
-	LLabel_Init( &s->lblUpdate,   "&eChecking..",      
+	LLabel_Init( &s->lblUpdate,   "&eChecking...",      
 				Updater_Supported ? main_lblUpdate_N : main_lblUpdate_H);
 	LButton_Init(&s->btnRegister, 100, 35, "Register", main_btnRegister);
 	LButton_Init(&s->btnOptions,  100, 35, "Options",  main_btnOptions);
@@ -906,7 +906,7 @@ static void MainScreen_LoginPhase2(struct MainScreen* s, const cc_string* user) 
 	String_Copy(&Launcher_Username, user);
 
 	FetchServersTask_Run();
-	LLabel_SetConst(&s->lblStatus, "&eRetrieving servers list..");
+	LLabel_SetConst(&s->lblStatus, "&eRetrieving servers list...");
 }
 
 static void MainScreen_SignInError(struct HttpRequest* req) {
@@ -1132,7 +1132,7 @@ static void FetchResourcesScreen_UpdateStatus(struct FetchResourcesScreen* s, in
 
 	String_InitArray(str, strBuffer);
 	count = Fetcher_Downloaded + 1;
-	String_Format3(&str, "&eFetching %c.. (%i/%i)", name, &count, &Resources_Count);
+	String_Format3(&str, "&eFetching %c... (%i/%i)", name, &count, &Resources_Count);
 
 	if (String_Equals(&str, &s->lblStatus.text)) return;
 	LLabel_SetText(&s->lblStatus, &str);
@@ -1219,7 +1219,7 @@ static void ServersScreen_Refresh(void* w) {
 
 	FetchServersTask_Run();
 	btn = &ServersScreen.btnRefresh;
-	LButton_SetConst(btn, "&eWorking..");
+	LButton_SetConst(btn, "&eWorking...");
 }
 
 static void ServersScreen_HashFilter(cc_string* str) {
@@ -1268,7 +1268,7 @@ static void ServersScreen_Init(struct LScreen* s_) {
 	s->widgets    = servers_widgets;
 	s->numWidgets = Array_Elems(servers_widgets);
 
-	LInput_Init( &s->iptSearch, 370, "Search servers..",               srv_iptSearch);
+	LInput_Init( &s->iptSearch, 370, "Search servers...",              srv_iptSearch);
 	LInput_Init( &s->iptHash,   475, "classicube.net/server/play/...", srv_iptHash);
 
 	LButton_Init(&s->btnBack,    110, 30, "Back",    srv_btnBack);
@@ -1743,8 +1743,8 @@ static void UpdatesScreen_Init(struct LScreen* s_) {
 	LLine_Init( &s->seps[0],   320,                   upd_seps0);
 	LLine_Init( &s->seps[1],   320,                   upd_seps1);
 
-	LLabel_Init( &s->lblRel, "Latest release: Checking..",   upd_lblRel);
-	LLabel_Init( &s->lblDev, "Latest dev build: Checking..", upd_lblDev);
+	LLabel_Init( &s->lblRel, "Latest release: Checking...",   upd_lblRel);
+	LLabel_Init( &s->lblDev, "Latest dev build: Checking...", upd_lblDev);
 	LLabel_Init( &s->lblStatus, "",           upd_lblStatus);
 	LButton_Init(&s->btnBack, 80, 35, "Back", upd_btnBack);
 

--- a/src/LScreens.c
+++ b/src/LScreens.c
@@ -224,7 +224,7 @@ static void ChooseModeScreen_Init(struct LScreen* s_) {
 	LLine_Init(  &s->seps[1], 490, mode_seps1);
 
 	LButton_Init(&s->btnEnhanced, 145, 35, "Enhanced",                        mode_btnEnhanced);
-	LLabel_Init( &s->lblEnhanced[0], "&eEnables custom blocks, changing env", mode_lblEnhanced0);
+	LLabel_Init( &s->lblEnhanced[0], "&eEnables custom blocks, changing env.", mode_lblEnhanced0);
 	LLabel_Init( &s->lblEnhanced[1], "&esettings, longer messages, and more", mode_lblEnhanced1);
 
 	LButton_Init(&s->btnClassicHax, 145, 35, "Classic +hax",                     mode_btnClassicHax);

--- a/src/Menus.c
+++ b/src/Menus.c
@@ -690,7 +690,7 @@ static const char* const optsGroup_descs[8] = {
 	"&eChat options",
 	"&eHacks allowed, jump settings, and more",
 	"&eEnv colours, water level, weather, and more",
-	"&eSettings for resembling the original classic",
+	"&eSettings for resembling the original Classic",
 };
 static const struct SimpleButtonDesc optsGroup_btns[8] = {
 	{ -160, -100, "Misc options...",      Menu_SwitchMisc        },
@@ -1436,7 +1436,7 @@ static void SaveLevelScreen_UploadCallback(const cc_string* path) {
 
 static void SaveLevelScreen_File(void* screen, void* b) {
 	static const char* const titles[] = {
-		"ClassiCube map", "Minecraft schematic", "Minecraft classic map", NULL
+		"ClassiCube map", "Minecraft schematic", "Minecraft Classic map", NULL
 	};
 	static const char* const filters[] = {
 		".cw", ".schematic", ".mine", NULL
@@ -3354,7 +3354,7 @@ static void NostalgiaFunctionalityScreen_InitWidgets(struct MenuOptionsScreen* s
 		{ -1,   0, "Allow custom blocks",  MenuOptionsScreen_Bool,
 			NostalgiaScreen_GetCustom,  NostalgiaScreen_SetCustom },
 
-		{  1, -50, "Non-classic features", MenuOptionsScreen_Bool,
+		{  1, -50, "Non-Classic features", MenuOptionsScreen_Bool,
 			NostalgiaScreen_GetCPE,     NostalgiaScreen_SetCPE },
 		{  1,   0, "Game version",         NostalgiaScreen_Version,
 			NostalgiaScreen_GetVersion, NostalgiaScreen_SetVersion }

--- a/src/Menus.c
+++ b/src/Menus.c
@@ -628,8 +628,8 @@ static void ClassicPauseScreen_Init(void* screen) {
 	static const struct SimpleButtonDesc descs[] = {
 		{    0, -100, "Options...",             Menu_SwitchClassicOptions },
 		{    0,  -50, "Generate new level...",  Menu_SwitchClassicGenLevel },
-		{    0,    0, "Save level..",           Menu_SwitchSaveLevel },
-		{    0,   50, "Load level..",           Menu_SwitchLoadLevel },
+		{    0,    0, "Save level...",          Menu_SwitchSaveLevel },
+		{    0,   50, "Load level...",          Menu_SwitchLoadLevel },
 		{    0,  100, "Nostalgia options...",   Menu_SwitchNostalgia }
 	};
 	s->widgets    = classicPause_widgets;
@@ -821,7 +821,7 @@ static void EditHotkeyScreen_UpdateBaseKey(struct EditHotkeyScreen* s) {
 	String_InitArray(text, textBuffer);
 
 	if (s->selectedI == 0) {
-		String_AppendConst(&text, "Key: press a key..");
+		String_AppendConst(&text, "Key: press a key...");
 	} else {
 		String_AppendConst(&text, "Key: ");
 		String_AppendConst(&text, Input_DisplayNames[s->curHotkey.trigger]);
@@ -834,7 +834,7 @@ static void EditHotkeyScreen_UpdateModifiers(struct EditHotkeyScreen* s) {
 	String_InitArray(text, textBuffer);
 
 	if (s->selectedI == 1) {
-		String_AppendConst(&text, "Modifiers: press a key..");
+		String_AppendConst(&text, "Modifiers: press a key...");
 	} else {
 		String_AppendConst(&text, "Modifiers:");
 		EditHotkeyScreen_MakeFlags(s->curHotkey.mods, &text);

--- a/src/Menus.c
+++ b/src/Menus.c
@@ -684,22 +684,22 @@ static struct Widget* optGroups_widgets[] = {
 
 static const char* const optsGroup_descs[8] = {
 	"&eMusic/Sound, view bobbing, and more",
-	"&eGui scale, font settings, and more",
+	"&eGUI scale, font settings, and more",
 	"&eFPS limit, view distance, entity names/shadows",
 	"&eSet key bindings, bind keys to act as mouse clicks",
 	"&eChat options",
 	"&eHacks allowed, jump settings, and more",
-	"&eEnv colours, water level, weather, and more",
+	"&eEnvironment colours, water level, weather, and more",
 	"&eSettings for resembling the original Classic",
 };
 static const struct SimpleButtonDesc optsGroup_btns[8] = {
-	{ -160, -100, "Misc options...",      Menu_SwitchMisc        },
-	{ -160,  -50, "Gui options...",       Menu_SwitchGui         },
+	{ -160, -100, "Misc. options...",     Menu_SwitchMisc        },
+	{ -160,  -50, "GUI options...",       Menu_SwitchGui         },
 	{ -160,    0, "Graphics options...",  Menu_SwitchGfx         },
 	{ -160,   50, "Controls...",          Menu_SwitchBindsNormal },
 	{  160, -100, "Chat options...",      Menu_SwitchChat        },
 	{  160,  -50, "Hacks settings...",    Menu_SwitchHacks       },
-	{  160,    0, "Env settings...",      Menu_SwitchEnv         },
+	{  160,    0, "Environment settings...", Menu_SwitchEnv         },
 	{  160,   50, "Nostalgia options...", Menu_SwitchNostalgia   }
 };
 
@@ -3284,7 +3284,7 @@ static void NostalgiaAppearanceScreen_InitWidgets(struct MenuOptionsScreen* s) {
 	static const struct MenuOptionDesc buttons[] = {
 		{ -1, -100, "Classic hand model",   MenuOptionsScreen_Bool,
 			NostalgiaScreen_GetHand,   NostalgiaScreen_SetHand },
-		{ -1,  -50, "Classic walk anim",    MenuOptionsScreen_Bool,
+		{ -1,  -50, "Classic walk animation", MenuOptionsScreen_Bool,
 			NostalgiaScreen_GetAnim,   NostalgiaScreen_SetAnim },
         { -1,    0, "Classic chat",    MenuOptionsScreen_Bool,
             NostalgiaScreen_GetClassicChat, NostalgiaScreen_SetClassicChat },

--- a/src/Program.c
+++ b/src/Program.c
@@ -63,7 +63,7 @@ static void SetupProgram(int argc, char** argv) {
 	Window_Init();
 	
 	if (res) Logger_SysWarn(res, "setting current directory");
-	Platform_LogConst("Starting " GAME_APP_NAME " ..");
+	Platform_LogConst("Starting " GAME_APP_NAME "...");
 	String_InitArray(Server.Address, ipBuffer);
 }
 

--- a/src/TexturePack.c
+++ b/src/TexturePack.c
@@ -205,7 +205,7 @@ static cc_bool UseDedicatedCache(cc_string* path, const cc_string* key) {
 	/*  (Several users have reported this happening on some Android devices) */
 	if (createdCache && res == 0) {
 		Chat_AddRaw("&cSomething has deleted system managed cache folder");
-		Chat_AddRaw("  &cFalling back to caching to game folder instead..");
+		Chat_AddRaw("  &cFalling back to caching to game folder instead...");
 		cacheInvalid = true;
 	}
 	if (res == 0) createdCache = true;


### PR DESCRIPTION
* Un-abbreviate uncommon abbreviations
* Punctuate abbreviations
* Capitalize acronyms
* Change two-dot ellipses to three-dot ellipses
* Capitalize “Minecraft Classic”