### PR TITLE
Use -f so 'make clean' doesn't fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ C_SOURCES:=$(wildcard src/*.c)
 C_OBJECTS:=$(patsubst %.c, %.o, $(C_SOURCES))
 OBJECTS:=$(C_OBJECTS)
 ENAME=ClassiCube
-DEL=rm
+DEL=rm -f
 CFLAGS=-g -pipe -fno-math-errno
 LDFLAGS=-g -rdynamic
 


### PR DESCRIPTION
This PR uses `rm -f` so that `make clean` doesn't fail when intermediate build products don't exist.