### PR TITLE
Allow modifying selected block outline appearance

### DIFF
--- a/src/Options.h
+++ b/src/Options.h
@@ -78,6 +78,10 @@ Copyright 2014-2023 ClassiCube | Licensed under BSD-3
 #define OPT_DPI_SCALING "win-dpi-scaling"
 #define OPT_GAME_VERSION "game-version"
 
+#define OPT_SELECTED_BLOCK_OUTLINE_COLOR "selected-block-outline-color"
+#define OPT_SELECTED_BLOCK_OUTLINE_OPACITY "selected-block-outline-opacity"
+#define OPT_SELECTED_BLOCK_OUTLINE_SCALE "selected-block-outline-scale"
+
 #define LOPT_SESSION  "launcher-session"
 #define LOPT_USERNAME "launcher-cc-username"
 #define LOPT_PASSWORD "launcher-cc-password"
@@ -112,15 +116,15 @@ void Options_PauseSaving(void);
 /* Sets value to value of option directly in Options.Buffer if found, String_Empty if not. */
 /* Returns whether the option was actually found. */
 STRING_REF cc_bool Options_UNSAFE_Get(const char* keyRaw, cc_string* value);
-/* Returns value of given option, or defalt value if not found. */
+/* Returns value of given option, or default value if not found. */
 CC_API void Options_Get(const char*        key, cc_string* value, const char* defValue);
-/* Returns value of given option as an integer, or defalt value if could not be converted. */
+/* Returns value of given option as an integer, or default value if could not be converted. */
 CC_API int  Options_GetInt(const char*     key, int min, int max, int defValue);
-/* Returns value of given option as a bool, or defalt value if could not be converted. */
+/* Returns value of given option as a bool, or default value if could not be converted. */
 CC_API cc_bool Options_GetBool(const char* key, cc_bool defValue);
-/* Returns value of given option as a float, or defalt value if could not be converted. */
+/* Returns value of given option as a float, or default value if could not be converted. */
 CC_API float Options_GetFloat(const char*  key, float min, float max, float defValue);
-/* Returns value of given option as an integer, or defalt value if could not be converted. */
+/* Returns value of given option as an integer, or default value if could not be converted. */
 /* NOTE: Conversion is done by going through all elements of names, returning index of a match. */
 CC_API int   Options_GetEnum(const char*   key, int defValue, const char* const* names, int namesCount);
 /* Attempts to parse the value of the given option into an RGB (3 byte) colour. */


### PR DESCRIPTION
I've added three new options which can be added into options.txt:

`selected-block-outline-color`
`selected-block-outline-opacity`
`selected-block-outline-scale`