### PR TITLE
changed "architecture.md" to "modules.md" in second topic so it refers to right doc file

### DIFF
--- a/doc/style.md
+++ b/doc/style.md
@@ -1,6 +1,6 @@
 ### Guidelines
 * Code should be C89 compatible and compilable as C++.
-* Each .c file should represent a module. (see architecture.md for more details)
+* Each .c file should represent a module. (see modules.md for more details)
 * Public functions and variables should be prefixed by module to avoid name collisions. (e.g. `Game_Reset`)
 * Private functions should be named using pascal case. Prefixing module is optional - do it when it makes sense.
 * Private variables don't really have a consistent style.


### PR DESCRIPTION
Under Guidelines, second topic oriented to see "architecture.md" for more details, which does not exist anymore, or was renamed. This pull request fixes that for clarity, referring to the modules.md which I believe to fulfill the same purpose.