### PR TITLE
make the UI actually legible on 3DS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ android/app/.externalNativeBuild/
 android/local.properties
 *.iml
 
+# 3DS build results
+build-3ds/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/src/LBackend.c
+++ b/src/LBackend.c
@@ -47,8 +47,14 @@ static int flagXOffset, flagYOffset;
 
 static void HookEvents(void);
 void LBackend_Init(void) {
-	xBorder = Display_ScaleX(1); xBorder2 = xBorder * 2; xBorder3 = xBorder * 3; xBorder4 = xBorder * 4;
-	yBorder = Display_ScaleY(1); yBorder2 = yBorder * 2; yBorder3 = yBorder * 3; yBorder4 = yBorder * 4;
+	xBorder = Display_ScaleX(1);
+	yBorder = Display_ScaleY(1);
+
+	if (xBorder < 1) { xBorder = 1; }
+	if (yBorder < 1) { yBorder = 1; }
+
+	xBorder2 = xBorder * 2; xBorder3 = xBorder * 3; xBorder4 = xBorder * 4;
+	yBorder2 = yBorder * 2; yBorder3 = yBorder * 3; yBorder4 = yBorder * 4;
 
 	xInputOffset = Display_ScaleX(5);
 	yInputOffset = Display_ScaleY(2);

--- a/src/LWidgets.c
+++ b/src/LWidgets.c
@@ -19,8 +19,14 @@ static int oneX, twoX, fourX;
 static int oneY, twoY, fourY;
 
 void LWidget_CalcOffsets(void) {
-	oneX = Display_ScaleX(1); twoX = oneX * 2; fourX = oneX * 4;
-	oneY = Display_ScaleY(1); twoY = oneY * 2; fourY = oneY * 4;
+	oneX = Display_ScaleX(1);
+	oneY = Display_ScaleY(1);
+
+	if (oneX < 1) { oneX = 1; }
+	if (oneY < 1) { oneY = 1; }
+
+	twoX = oneX * 2; fourX = oneX * 4;
+	twoY = oneY * 2; fourY = oneY * 4;
 
 	flagXOffset  = Display_ScaleX(2);
 	flagYOffset  = Display_ScaleY(6);

--- a/src/Launcher.c
+++ b/src/Launcher.c
@@ -529,7 +529,7 @@ void Launcher_DrawTitle(struct FontDesc* font, const char* text, struct Context2
 	int x;
 
 	/* Skip dragging logo when very small window to save space */
-	if (WindowInfo.Height < 300) return;
+	if (WindowInfo.Height < 240) return;
 
 	DrawTextArgs_Make(&args, &title, font, false);
 	x = ctx->width / 2 - Drawer2D_TextWidth(&args) / 2;

--- a/src/Window_3DS.c
+++ b/src/Window_3DS.c
@@ -18,9 +18,9 @@ static Result irrst_result;
 
 struct _DisplayData DisplayInfo;
 struct _WinData WindowInfo;
-// no DPI scaling on 3DS
-int Display_ScaleX(int x) { return x; }
-int Display_ScaleY(int y) { return y; }
+// Render everything at half size due to the small resolution
+int Display_ScaleX(int x) { return x / 2; }
+int Display_ScaleY(int y) { return y / 2; }
 
 
 // Note from https://github.com/devkitPro/libctru/blob/master/libctru/include/3ds/gfx.h
@@ -42,8 +42,8 @@ void Window_Init(void) {
 	DisplayInfo.Width  = height; // deliberately swapped
 	DisplayInfo.Height = width;  // deliberately swapped
 	DisplayInfo.Depth  = 4; // 32 bit
-	DisplayInfo.ScaleX = 1;
-	DisplayInfo.ScaleY = 1;
+	DisplayInfo.ScaleX = 0.5;
+	DisplayInfo.ScaleY = 0.5;
 	
 	WindowInfo.Width   = height; // deliberately swapped
 	WindowInfo.Height  = width;  // deliberately swapped

--- a/src/Window_3DS.c
+++ b/src/Window_3DS.c
@@ -101,10 +101,10 @@ static void HandleButtons(u32 mods) {
 
 static void ProcessJoystickInput(circlePosition* pos, double delta) {
 	float scale = (delta * 60.0) / 8.0f;
-	
+
 	// May not be exactly 0 on actual hardware
-	if (Math_AbsI(pos->dx) <= 8) pos->dx = 0;
-	if (Math_AbsI(pos->dy) <= 8) pos->dy = 0;
+	if (Math_AbsI(pos->dx) <= 16) pos->dx = 0;
+	if (Math_AbsI(pos->dy) <= 16) pos->dy = 0;
 		
 	Event_RaiseRawMove(&PointerEvents.RawMoved, pos->dx * scale, -pos->dy * scale);
 }
@@ -148,7 +148,6 @@ void Window_ProcessEvents(double delta) {
 		hidCircleRead(&pos);
 		ProcessJoystickInput(&pos, delta);
 	}
-	
 	if (Input.RawMode && irrst_result == 0) {
 		circlePosition pos;
 		irrstScanInput();


### PR DESCRIPTION
This basically scales every UI widget to half size so that it all fits on screen and is readable. I'm not entirely sure why there's both a `DisplayInfo.ScaleX/ScaleY` and a `Display_ScaleX/Display_ScaleY` function and when to use either. Seems redundant.