### PR TITLE
Add custom FPS option

### DIFF
--- a/src/Game.c
+++ b/src/Game.c
@@ -51,7 +51,7 @@ int Game_ViewDistance     = DEFAULT_VIEWDIST;
 int Game_UserViewDistance = DEFAULT_VIEWDIST;
 int Game_MaxViewDistance  = DEFAULT_MAX_VIEWDIST;
 
-int     Game_FpsLimit, Game_Vertices;
+int     Game_FpsLimit, Game_MaxFps, Game_Vertices;
 cc_bool Game_SimpleArmsAnim;
 static cc_bool gameRunning;
 static float gfx_minFrameMs;
@@ -74,7 +74,7 @@ int Game_NumStates = 1;
 #endif
 
 const char* const FpsLimit_Names[FPS_LIMIT_COUNT] = {
-	"LimitVSync", "Limit30FPS", "Limit60FPS", "Limit120FPS", "Limit144FPS", "LimitNone",
+	"LimitVSync", "LimitCustom", "LimitNone",
 };
 
 static struct IGameComponent* comps_head;
@@ -317,6 +317,7 @@ static void HandleInactiveChanged(void* obj) {
 	} else {
 		Chat_AddOf(&String_Empty,       MSG_TYPE_EXTRASTATUS_2);
 		Game_SetFpsLimit(Game_FpsLimit);
+		Game_SetMaxFps(Game_MaxFps);
 
 		Gfx.ReducedPerfMode         = false;
 		Gfx.ReducedPerfModeCooldown = 2;
@@ -413,6 +414,7 @@ static void Game_Load(void) {
 	struct IGameComponent* comp;
 	Game_UpdateDimensions();
 	Game_SetFpsLimit(Options_GetEnum(OPT_FPS_LIMIT, 0, FpsLimit_Names, FPS_LIMIT_COUNT));
+	Game_SetMaxFps(Options_GetInt(OPT_MAX_FPS, 10, 1000, 60));
 	Gfx_Create();
 	
 	Logger_WarnFunc = Game_WarnFunc;
@@ -480,17 +482,14 @@ static void Game_Load(void) {
 }
 
 void Game_SetFpsLimit(int method) {
-	float minFrameTime = 0;
 	Game_FpsLimit = method;
-
-	switch (method) {
-	case FPS_LIMIT_144: minFrameTime = 1000/144.0f; break;
-	case FPS_LIMIT_120: minFrameTime = 1000/120.0f; break;
-	case FPS_LIMIT_60:  minFrameTime = 1000/60.0f;  break;
-	case FPS_LIMIT_30:  minFrameTime = 1000/30.0f;  break;
-	}
 	Gfx_SetVSync(method == FPS_LIMIT_VSYNC);
-	Game_SetMinFrameTime(minFrameTime);
+	Game_SetMinFrameTime(method == FPS_LIMIT_CUSTOM ? 1000.0f / Game_MaxFps : 0);
+}
+
+void Game_SetMaxFps(int max) {
+	Game_MaxFps = max;
+	if (Game_FpsLimit == FPS_LIMIT_CUSTOM) Game_SetMinFrameTime(1000.0f / max);
 }
 
 #ifdef CC_BUILD_WEB

--- a/src/Game.h
+++ b/src/Game.h
@@ -52,6 +52,7 @@ extern int Game_UserViewDistance;
 
 /* Strategy used to limit FPS (see FpsLimitMethod enum) */
 extern int     Game_FpsLimit;
+extern int     Game_MaxFps;
 extern cc_bool Game_SimpleArmsAnim;
 extern int     Game_Vertices;
 
@@ -84,7 +85,7 @@ extern struct GameVersion Game_Version;
 extern void GameVersion_Load(void);
 
 enum FpsLimitMethod {
-	FPS_LIMIT_VSYNC, FPS_LIMIT_30, FPS_LIMIT_60, FPS_LIMIT_120, FPS_LIMIT_144, FPS_LIMIT_NONE, FPS_LIMIT_COUNT
+	FPS_LIMIT_VSYNC, FPS_LIMIT_CUSTOM, FPS_LIMIT_NONE, FPS_LIMIT_COUNT
 };
 extern const char* const FpsLimit_Names[FPS_LIMIT_COUNT];
 
@@ -113,6 +114,8 @@ void Game_UpdateDimensions(void);
 /* Sets the strategy/method used to limit frames per second. */
 /* See FPS_LIMIT_ for valid strategies/methods */
 void Game_SetFpsLimit(int method);
+/* Sets the FPS cap used by the FPS_LIMIT_CUSTOM method */
+void Game_SetMaxFps(int max);
 void Game_SetMinFrameTime(float frameTimeMS);
 
 cc_bool Game_UpdateTexture(GfxResourceID* texId, struct Stream* src, const cc_string* file, 

--- a/src/MenuOptions.c
+++ b/src/MenuOptions.c
@@ -715,15 +715,37 @@ void EnvSettingsScreen_Show(void) {
 /*########################################################################################################################*
 *--------------------------------------------------GraphicsOptionsScreen--------------------------------------------------*
 *#########################################################################################################################*/
-static void GrO_CheckLightingModeAllowed(struct MenuOptionsScreen* s) {
-	Widget_SetDisabled(s->widgets[3], Lighting_ModeLockedByServer);
+static void Gr0_CheckCustomFpsLimitEnabled(struct MenuOptionsScreen* s) {
+	Widget_SetDisabled(s->widgets[1], Game_FpsLimit != FPS_LIMIT_CUSTOM);
 }
 
-static int  GrO_GetFPS(void) { return Game_FpsLimit; }
-static void GrO_SetFPS(int v) {
-	cc_string str = String_FromReadonly(FpsLimit_Names[v]);
+static void GrO_CheckLightingModeAllowed(struct MenuOptionsScreen* s) {
+	Widget_SetDisabled(s->widgets[4], Lighting_ModeLockedByServer);
+}
+
+static void GraphicsOptionsScreen_FpsLimit(void* screen, void* widget) {
+	struct MenuOptionsScreen* s = (struct MenuOptionsScreen*)screen;
+	struct ButtonWidget* btn = (struct ButtonWidget*)widget;
+
+	int method = Game_FpsLimit + 1;
+	if (method >= FPS_LIMIT_COUNT) method = 0;
+
+	cc_string str = String_FromReadonly(FpsLimit_Names[method]);
 	Options_Set(OPT_FPS_LIMIT, &str);
-	Game_SetFpsLimit(v);
+	Game_SetFpsLimit(method);
+	Gr0_CheckCustomFpsLimitEnabled(s);
+	MenuOptionsScreen_Update(s, btn);
+}
+
+static void GrO_GetFPSLimit(struct ButtonWidget* btn, cc_string* v) {
+	String_AppendConst(v, FpsLimit_Names[Game_FpsLimit]);
+}
+static void GrO_SetFPSLimit(struct ButtonWidget* btn, const cc_string* v) { }
+
+static int  GrO_GetMaxFPS(void) { return Game_MaxFps; }
+static void GrO_SetMaxFPS(int v) {
+	Options_SetInt(OPT_MAX_FPS, v);
+	Game_SetMaxFps(v);
 }
 
 static int  GrO_GetViewDist(void) { return Game_ViewDistance; }
@@ -770,12 +792,14 @@ static void    GrO_SetMipmaps(cc_bool v) {
 static void GraphicsOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 	MenuOptionsScreen_BeginButtons(s);
 	{
-		MenuOptionsScreen_AddEnum(s, "FPS mode", FpsLimit_Names, FPS_LIMIT_COUNT,
-			GrO_GetFPS,        GrO_SetFPS,
+		MenuOptionsScreen_AddButton(s, "FPS mode", GraphicsOptionsScreen_FpsLimit,
+			GrO_GetFPSLimit,   GrO_SetFPSLimit,
 			"&eVSync: &fNumber of frames rendered is at most the monitor's refresh rate.\n" \
-			"&e30/60/120/144 FPS: &fRenders 30/60/120/144 frames at most each second.\n" \
+			"&eCustom: &fRenders a specified number of frames at most each second.\n" \
 			"&eNoLimit: &fRenders as many frames as possible each second.\n" \
 			"&cNoLimit is pointless - it wastefully renders frames that you don't even see!");
+		MenuOptionsScreen_AddInt(s, "Max FPS", 10, 1000, 60,
+			GrO_GetMaxFPS,     GrO_SetMaxFPS, NULL);
 		MenuOptionsScreen_AddInt(s, "View distance",
 			8, 4096, 512,
 			GrO_GetViewDist,   GrO_SetViewDist, NULL);
@@ -815,6 +839,7 @@ static void GraphicsOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 	};
 	MenuOptionsScreen_EndButtons(s, Menu_SwitchOptions);
 	s->OnLightingModeServerChanged = GrO_CheckLightingModeAllowed;
+	Gr0_CheckCustomFpsLimitEnabled(s);
 	GrO_CheckLightingModeAllowed(s);
 }
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -20,6 +20,7 @@ Copyright 2014-2023 ClassiCube | Licensed under BSD-3
 #define OPT_INVERT_MOUSE "invertmouse"
 #define OPT_SENSITIVITY "mousesensitivity"
 #define OPT_FPS_LIMIT "fpslimit"
+#define OPT_MAX_FPS "maxfps"
 #define OPT_DEFAULT_TEX_PACK "defaulttexpack"
 #define OPT_VIEW_BOBBING "viewbobbing"
 #define OPT_ENTITY_SHADOW "entityshadow"

--- a/src/Screens.c
+++ b/src/Screens.c
@@ -2173,7 +2173,10 @@ static void DisconnectScreen_Render(void* screen, float delta) {
 	Screen_Render2Widgets(screen, delta);
 }
 
-static void DisconnectScreen_Free(void* screen) { Game_SetFpsLimit(Game_FpsLimit); }
+static void DisconnectScreen_Free(void* screen) {
+	Game_SetFpsLimit(Game_FpsLimit);
+	Game_SetMaxFps(Game_MaxFps);
+}
 
 static const struct ScreenVTABLE DisconnectScreen_VTABLE = {
 	DisconnectScreen_Init,   DisconnectScreen_Update, DisconnectScreen_Free,


### PR DESCRIPTION
Replaces `Limit30FPS`, `Limit60FPS`, `Limit120FPS`, and `Limit144FPS` FPS modes with `LimitCustom` and adds a new option which allows players to set a custom FPS cap between 10 and 1000 FPS. The option is disabled if the FPS limit is set to anything other than `LimitCustom`.

![image](https://github.com/user-attachments/assets/73f5d54c-243a-4851-8477-73ea6804f0d8)

![image](https://github.com/user-attachments/assets/2af657cd-0f19-4c83-b1ea-a49c6b953678)

Resolves #993, resolves #1254, supersedes #1255.