### PR TITLE
SDL3: fix operation not permitted when entering/exiting fullscreen

### DIFF
--- a/src/Window_SDL3.c
+++ b/src/Window_SDL3.c
@@ -127,10 +127,10 @@ int Window_GetWindowState(void) {
 }
 
 cc_result Window_EnterFullscreen(void) {
-	return SDL_SetWindowFullscreen(win_handle, true);
+	return SDL_SetWindowFullscreen(win_handle, true) ? 0 : -1;
 }
 cc_result Window_ExitFullscreen(void) { 
-	return SDL_SetWindowFullscreen(win_handle, false);
+	return SDL_SetWindowFullscreen(win_handle, false) ? 0 : -1;
 }
 
 int Window_IsObscured(void) {


### PR DESCRIPTION
In SDL3, the SDL_SetWindowFullscreen function has been changed to return true or false instead of 0 or -1.  So I made the function return 0 or -1 like it used to.