### PR TITLE
Add PushStrength to EntityProperty v2

### DIFF
--- a/src/Entity.c
+++ b/src/Entity.c
@@ -43,6 +43,7 @@ void Entity_Init(struct Entity* e) {
 	e->Flags      = ENTITY_FLAG_HAS_MODELVB;
 	e->uScale     = 1.0f;
 	e->vScale     = 1.0f;
+	e->PushStrength = 1.0f;
 	e->_skinReqID = 0;
 	e->SkinRaw[0] = '\0';
 	e->NameRaw[0] = '\0';

--- a/src/Entity.h
+++ b/src/Entity.h
@@ -108,6 +108,7 @@ struct Entity {
 	Vec3 Position;
 	/* NOTE: Do NOT change order of yaw/pitch, this will break models in plugins */
 	float Pitch, Yaw, RotX, RotY, RotZ;
+	float PushStrength;
 	Vec3 Velocity;
 
 	struct Model* Model;

--- a/src/EntityComponents.c
+++ b/src/EntityComponents.c
@@ -1047,7 +1047,7 @@ void PhysicsComp_DoEntityPush(struct Entity* entity) {
 		if (dist < 0.002f || dist > 1.0f) continue; /* TODO: range needs to be lower? */
 
 		Vec3_Normalise(&dir);
-		pushStrength = (1 - dist) / 32.0f; /* TODO: should be 24/25 */
+		pushStrength = (entity->PushStrength - dist) / 32.0f; /* TODO: should be 24/25 */
 		/* entity.Velocity -= dir * pushStrength */
 		Vec3_Mul1By(&dir, pushStrength);
 		Vec3_SubBy(&entity->Velocity, &dir);

--- a/src/Protocol.c
+++ b/src/Protocol.c
@@ -80,7 +80,7 @@ static struct CpeExt
 	bulkBlockUpdate_Ext = { "BulkBlockUpdate", 1 },
 	textColors_Ext      = { "TextColors", 1 },
 	envMapAspect_Ext    = { "EnvMapAspect", 2 },
-	entityProperty_Ext  = { "EntityProperty", 1 },
+	entityProperty_Ext  = { "EntityProperty", 2 },
 	extEntityPos_Ext    = { "ExtEntityPositions", 1 },
 	twoWayPing_Ext      = { "TwoWayPing", 1 },
 	invOrder_Ext        = { "InventoryOrder", 1 },
@@ -1428,6 +1428,10 @@ static void CPE_SetEntityProperty(cc_uint8* data) {
 
 		Entity_UpdateModelBounds(e);
 		return;
+	case 6:
+		if (value < -1024.0f) value = -1024.0f;
+		if (value > 1024.0f) value = 1024.0f;
+		e->PushStrength = (float)value; return;
 	default:
 		return;
 	}


### PR DESCRIPTION
This update allows server owners to configure how far players get pushed by entities when pushing is enabled. This also allows players to have varying push sizes instead of all sharing the same value. Currently, it's clamped between -1024 and 1024 as I don't think going out of these ranges would be useful, but happy to change.