### PR TITLE
Enable file sharing in Files app

### DIFF
--- a/misc/ios/Info.plist
+++ b/misc/ios/Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>LSRequiresIPhoneOS</key>
 	<false/>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
This is the last piece needed to make ClassiCube files visible in the Files app (available in iOS 11 and later). Apple requires both `UIFileSharingEnabled` and `LSSupportsOpeningDocumentsInPlace` to be true, despite the misleading names. You can't directly edit .txt files, but you can copy and replace it as well as bringing in zip files.

<img width="585" height="1266" alt="image" src="https://github.com/user-attachments/assets/0cdbf42c-7c87-4fd8-b24d-6cb79d6b34f2" />
