### PR TITLE
Implement global GUI scale option independent of window size

### DIFF
--- a/src/Gui.c
+++ b/src/Gui.c
@@ -30,43 +30,27 @@ static GfxResourceID bars_VB;
 /*########################################################################################################################*
 *----------------------------------------------------------Gui------------------------------------------------------------*
 *#########################################################################################################################*/
-static CC_NOINLINE int GetWindowScale(void) {
-	float widthScale  = Window_Main.Width  * Window_Main.UIScaleX;
-	float heightScale = Window_Main.Height * Window_Main.UIScaleY;
-
-	/* Use larger UI scaling on mobile */
-	/* TODO move this DPI scaling elsewhere.,. */
-#ifndef CC_BUILD_DUALSCREEN
-	if (!Gui_TouchUI) {
-#endif
-		widthScale  /= DisplayInfo.ScaleX;
-		heightScale /= DisplayInfo.ScaleY;
-#ifndef CC_BUILD_DUALSCREEN
-	}
-#endif
-	return 1 + (int)(min(widthScale, heightScale));
-}
 
 float Gui_Scale(float value) {
-	return (float)((int)(value * 10 + 0.5f)) / 10.0f;
+	return (float)((int)(value * Gui.GlobalScale * 10 + 0.5f)) / 10.0f;
 }
 
 float Gui_GetHotbarScale(void) {
-	return Gui_Scale(GetWindowScale() * Gui.RawHotbarScale);
+	return Gui_Scale(Gui.RawHotbarScale);
 }
 
 float Gui_GetInventoryScale(void) {
-	return Gui_Scale(GetWindowScale() * (Gui.RawInventoryScale * 0.5f));
+	return Gui_Scale(Gui.RawInventoryScale);
 }
 
 float Gui_GetChatScale(void) {
-	if (Gui.AutoScaleChat) return Gui_Scale(GetWindowScale() * Gui.RawChatScale);
+	if (Gui.AutoScaleChat) return Gui_Scale(Gui.RawChatScale);
 	return Gui.RawChatScale;
 }
 
 float Gui_GetCrosshairScale(void) {
-	float heightScale = Window_Main.Height * Window_Main.UIScaleY;
-	return Gui_Scale(heightScale) * Gui.RawCrosshairScale;
+	/* Scale multiplied by 0.5 because the crosshair is strangely bigger than other HUD items */
+	return Gui_Scale(Gui.RawCrosshairScale * 0.5f);
 }
 
 
@@ -133,6 +117,7 @@ static void LoadOptions(void) {
 	Gui.RawChatScale      = Options_GetFloat(OPT_CHAT_SCALE,      0.25f, 5.0f, 1.0f);
 	Gui.RawCrosshairScale = Options_GetFloat(OPT_CROSSHAIR_SCALE, 0.25f, 5.0f, 1.0f);
 	Gui.RawTouchScale     = Options_GetFloat(OPT_TOUCH_SCALE,     0.25f, 5.0f, 1.0f);
+	Gui.GlobalScale       = Options_GetFloat(OPT_GLOBAL_SCALE,     1.0f, 5.0f, 2.0f);
 
 	Gui.AutoScaleChat     = Options_GetBool(OPT_CHAT_AUTO_SCALE, true);
 }

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -53,6 +53,7 @@ CC_VAR extern struct _GuiData {
 	int DefaultLines;
 	int _unused;
 	float RawTouchScale;
+	float GlobalScale;
 	/* The highest priority screen that has grabbed input. */
 	struct Screen* InputGrab;
 	/* Whether chat automatically scales based on window size. */

--- a/src/MenuOptions.c
+++ b/src/MenuOptions.c
@@ -905,6 +905,11 @@ static void    GuO_SetShowFPS(cc_bool v) {
 	Options_SetBool(OPT_SHOW_FPS, v);
 }
 
+static void GuO_GetGuiScale(cc_string* v) { String_AppendFloat(v, Gui.GlobalScale, 1); }
+static void GuO_SetGuiScale(const cc_string* v) { 
+	ChatOptionsScreen_SetScale(v, &Gui.GlobalScale, OPT_GLOBAL_SCALE); 
+}
+
 static void GuO_GetHotbar(cc_string* v) { String_AppendFloat(v, Gui.RawHotbarScale, 1); }
 static void GuO_SetHotbar(const cc_string* v) { 
 	ChatOptionsScreen_SetScale(v, &Gui.RawHotbarScale, OPT_HOTBAR_SCALE); 
@@ -938,6 +943,9 @@ static void GuiOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 	{
 		MenuOptionsScreen_AddBool(s, "Show FPS",
 			GuO_GetShowFPS,   GuO_SetShowFPS, NULL);
+		MenuOptionsScreen_AddNum(s,  "GUI scale",
+			0.25f, 4.00f, 1,
+			GuO_GetGuiScale, GuO_SetGuiScale, NULL);
 		MenuOptionsScreen_AddNum(s,  "Hotbar scale",
 			0.25f, 4.00f, 1,
 			GuO_GetHotbar,    GuO_SetHotbar, NULL);

--- a/src/Options.h
+++ b/src/Options.h
@@ -57,6 +57,7 @@ Copyright 2014-2025 ClassiCube | Licensed under BSD-3
 #define OPT_SHOW_FPS "gui-showfps"
 #define OPT_FONT_NAME "gui-fontname"
 #define OPT_BLACK_TEXT "gui-blacktextshadows"
+#define OPT_GLOBAL_SCALE "gui-globalscale"
 
 #define OPT_LANDSCAPE_MODE "landscape-mode"
 #define OPT_CLASSIC_MODE "mode-classic"


### PR DESCRIPTION
Intended to fix #1456.

Scaling is no longer based on the size of the game window. Now, there's a "global scale" value that the user can change. 1.0 represents the real size of the GUI graphics, while 2.0 is the default, matching classic Minecraft behavior.

I still haven't figured out how to change the size of the menu or status text. I don't think this will be complete until that's implemented. Additionally, I think it would be better if the GUI had an automatic scaling option which could select the best global scale value for the user's screen resolution. I'm just not sure how to implement these features yet.