### PR TITLE
Build 32-bit with -march=i486

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -44,14 +44,13 @@ jobs:
           LIBS: "-lX11 -lXi -lpthread -lGL -lm -ldl"
           SRCS: "src/*.c third_party/bearssl/*.c"
           FLAGS: "-O1 -s -fno-stack-protector -fno-math-errno -Qn -Werror -fvisibility=hidden -rdynamic -Werror"
-          NIX32_FLAGS:  "-no-pie -fno-pie -m32 -march=i486 -fcf-protection=none -L ./lib -Wl,--unresolved-symbols=ignore-in-shared-libs"
+          NIX32_FLAGS:  "-no-pie -fno-pie -m32 -fcf-protection=none -L ./lib -Wl,--unresolved-symbols=ignore-in-shared-libs"
         run: |
           LATEST_FLAG=-DCC_COMMIT_SHA=\"${GITHUB_SHA::9}\"
           
           gcc ${{ env.SRCS }} ${{ env.FLAGS }} ${{ env.NIX32_FLAGS }} $LATEST_FLAG -o cc-nix32-gl1 ${{ env.LIBS }}
           gcc ${{ env.SRCS }} ${{ env.FLAGS }} ${{ env.NIX32_FLAGS }} $LATEST_FLAG -DCC_GFX_BACKEND=CC_GFX_BACKEND_GL2 -o cc-nix32-gl2 ${{ env.LIBS }}
-      
-      
+
       - uses: ./.github/actions/upload_build
         if: ${{ always() && steps.compile.outcome == 'success' }}
         with:
@@ -63,6 +62,32 @@ jobs:
         with:
           SOURCE_FILE: 'cc-nix32-gl2'
           DEST_NAME: 'ClassiCube-Linux32-ModernGL'
+
+      - name: Compile 32 bit Linux builds (in i486)
+        shell: bash
+        id: compile-i486
+        env: 
+          LIBS: "-lX11 -lXi -lpthread -lGL -lm -ldl"
+          SRCS: "src/*.c third_party/bearssl/*.c"
+          FLAGS: "-O1 -s -fno-stack-protector -fno-math-errno -Qn -Werror -fvisibility=hidden -rdynamic -Werror"
+          NIX32_FLAGS:  "-no-pie -fno-pie -m32 -march=i486 -fcf-protection=none -L ./lib -Wl,--unresolved-symbols=ignore-in-shared-libs"
+        run: |
+          LATEST_FLAG=-DCC_COMMIT_SHA=\"${GITHUB_SHA::9}\"
+          
+          gcc ${{ env.SRCS }} ${{ env.FLAGS }} ${{ env.NIX32_FLAGS }} $LATEST_FLAG -o cc-nix32-gl1-i486 ${{ env.LIBS }}
+          gcc ${{ env.SRCS }} ${{ env.FLAGS }} ${{ env.NIX32_FLAGS }} $LATEST_FLAG -DCC_GFX_BACKEND=CC_GFX_BACKEND_GL2 -o cc-nix32-gl2-i486 ${{ env.LIBS }}
+            
+      - uses: ./.github/actions/upload_build
+        if: ${{ always() && steps.compile.outcome == 'success' }}
+        with:
+          SOURCE_FILE: 'cc-nix32-gl1-i486'
+          DEST_NAME: 'ClassiCube-Linux32-OpenGL-i486'
+          
+      - uses: ./.github/actions/upload_build
+        if: ${{ always() && steps.compile.outcome == 'success' }}
+        with:
+          SOURCE_FILE: 'cc-nix32-gl2-i486'
+          DEST_NAME: 'ClassiCube-Linux32-ModernGL-i486'
           
           
       - uses: ./.github/actions/notify_success
@@ -148,5 +173,6 @@ jobs:
         with:
           NOTIFY_MESSAGE: 'Failed to produce 64 bit Linux build'
           WEBHOOK_URL: '${{ secrets.WEBHOOK_URL }}'
+
 
 


### PR DESCRIPTION
This should explain a lot: https://youtu.be/-DiK5FDpBTg?t=1211

More specifically, this should be the problem:
<img width="771" height="217" alt="{85533CD8-4F55-43D4-9776-58E483CBDD11}" src="https://github.com/user-attachments/assets/37811c66-1390-4b9d-8bda-029dd28810c0" />

If we can verify that the prebuilt dynamic library is also march=pentium compatible that would be even better