### PR TITLE
Enable RAM disk on GameCube

### DIFF
--- a/src/gcwii/Platform_GCWii.h
+++ b/src/gcwii/Platform_GCWii.h
@@ -299,6 +299,9 @@ static void CreateRootDirectory(void) {
 }
 
 void Platform_Init(void) {
+#ifndef HW_RVL
+	AR_FormatDisk(true);
+#endif
 	fat_available = fatInitDefault();
 	Platform_ReadonlyFilesystem = !fat_available;
 

--- a/src/gcwii/Platform_Gamecube.c
+++ b/src/gcwii/Platform_Gamecube.c
@@ -22,6 +22,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <network.h>
+#include <ogc/aram.h>
 #include <ogc/cache.h>
 #include <ogc/lwp.h>
 #include <ogc/mutex.h>


### PR DESCRIPTION
This allows Dolphin to save data, albeit temporarily.
This is brand new functionality, so make sure your packages are up-to-date!

The following `Dolphin.ini` settings are required:
```ini
[Core]
HSPDevice = 1
ARAMExpansionSize = 0x2000000
```

Tested on real hardware using a prototype 32 MiB Memory Expansion Pak by webhdx.