### PR TITLE
Handle POWER/RESET Buttons on Wii/GameCube

### DIFF
--- a/src/gcwii/Window_GCWii.c
+++ b/src/gcwii/Window_GCWii.c
@@ -30,11 +30,6 @@ void* Window_XFB;
 struct _DisplayData DisplayInfo;
 struct cc_window WindowInfo;
 
-
-static void OnPowerOff(void) {
-	Window_Main.Exists = false;
-	Window_RequestClose();
-}
 static void InitVideo(void) {
 	VIDEO_Init();
 
@@ -58,10 +53,6 @@ static void InitVideo(void) {
 }
 
 void Window_PreInit(void) {
-	// TODO: SYS_SetResetCallback(reload); too? not sure how reset differs on GC/WII
-	#if defined HW_RVL
-	SYS_SetPowerCallback(OnPowerOff);
-	#endif
 	InitVideo();
 
 	DisplayInfo.Width  = cur_mode->fbWidth;
@@ -280,15 +271,22 @@ static void ProcessMouseInput(float delta) {
 /*########################################################################################################################*
 *----------------------------------------------------Input processing-----------------------------------------------------*
 *#########################################################################################################################*/
+void Window_ProcessEvents(float delta) {
+	if (!SYS_MainLoop()) {
+		Window_Main.Exists = false;
+		Window_RequestClose();
+		return;
+	}
+	#if defined HW_RVL
+	ProcessKeyboardInput();
+	ProcessMouseInput(delta);
+	#endif
+}
+
 #if defined HW_RVL
 static int dragCurX, dragCurY;
 static int dragStartX, dragStartY;
 static cc_bool dragActive;
-
-void Window_ProcessEvents(float delta) {
-	ProcessKeyboardInput();
-    ProcessMouseInput(delta);
-}
 
 static void GetIRPos(int res, int* x, int* y) {
 	if (res == WPAD_ERR_NONE) {
@@ -344,9 +342,6 @@ void Window_UpdateRawMouse(void)  {
 	dragCurX = x; dragCurY = y;
 }
 #else
-void Window_ProcessEvents(float delta) {
-}
-
 void Window_UpdateRawMouse(void) { }
 #endif
 


### PR DESCRIPTION
The POWER button now actually powers off the Wii, and the RESET button returns to loader on GameCube.

This depends on functionality that was added just yesterday on the libogc2 side, so make sure to update your local packages.