### PR TITLE
Expanded GUI scaling options

### DIFF
--- a/src/Gui.c
+++ b/src/Gui.c
@@ -30,7 +30,7 @@ static GfxResourceID bars_VB;
 /*########################################################################################################################*
 *----------------------------------------------------------Gui------------------------------------------------------------*
 *#########################################################################################################################*/
-static CC_NOINLINE int GetWindowScale(void) {
+int Gui_GetMaxScale(void) {
 	float widthScale  = Window_Main.Width  * Window_Main.UIScaleX;
 	float heightScale = Window_Main.Height * Window_Main.UIScaleY;
 
@@ -47,6 +47,11 @@ static CC_NOINLINE int GetWindowScale(void) {
 	return 1 + (int)(min(widthScale, heightScale));
 }
 
+static CC_NOINLINE int GetWindowScale(void) {
+	if (Gui.AutoScaleChat) return Gui_GetMaxScale();
+	return Gui.GlobalScale;
+}
+
 float Gui_Scale(float value) {
 	return (float)((int)(value * 10 + 0.5f)) / 10.0f;
 }
@@ -56,17 +61,20 @@ float Gui_GetHotbarScale(void) {
 }
 
 float Gui_GetInventoryScale(void) {
-	return Gui_Scale(GetWindowScale() * (Gui.RawInventoryScale * 0.5f));
+	return Gui_Scale(GetWindowScale() * Gui.RawInventoryScale * 0.5f);
 }
 
 float Gui_GetChatScale(void) {
-	if (Gui.AutoScaleChat) return Gui_Scale(GetWindowScale() * Gui.RawChatScale);
-	return Gui.RawChatScale;
+	return Gui_Scale(GetWindowScale() * Gui.RawChatScale);
 }
 
 float Gui_GetCrosshairScale(void) {
-	float heightScale = Window_Main.Height * Window_Main.UIScaleY;
-	return Gui_Scale(heightScale) * Gui.RawCrosshairScale;
+	if (Gui.AutoScaleChat) {
+		float heightScale = Window_Main.Height * Window_Main.UIScaleY;
+		return Gui_Scale(heightScale) * Gui.RawCrosshairScale;
+	}
+
+	return Gui.GlobalScale * Gui.RawCrosshairScale * 0.5f;
 }
 
 
@@ -135,7 +143,8 @@ static void LoadOptions(void) {
 	Gui.RawCrosshairScale = Options_GetFloat(OPT_CROSSHAIR_SCALE, 0.25f, 5.0f, 1.0f);
 	Gui.RawTouchScale     = Options_GetFloat(OPT_TOUCH_SCALE,     0.25f, 5.0f, 1.0f);
 
-	Gui.AutoScaleChat     = Options_GetBool(OPT_CHAT_AUTO_SCALE, true);
+	Gui.GlobalScale       = Options_GetFloat(OPT_GUI_SCALE,       1.00f, (float) Gui_GetMaxScale(), 2);
+	Gui.AutoScaleChat     = Options_GetBool(OPT_CHAT_AUTO_SCALE,  true);
 }
 
 static void LoseAllScreens(void) {

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -49,6 +49,8 @@ CC_VAR extern struct _GuiData {
 	/* Whether classic-style inventory is used */
 	cc_bool ClassicInventory;
 	float RawHotbarScale, RawChatScale, RawInventoryScale, RawCrosshairScale;
+	/* Baseline scale for all HUD screens, when automatic scaling isn't used */
+	float GlobalScale;
 	GfxResourceID GuiTex, GuiClassicTex, IconsTex, TouchTex;
 	int DefaultLines;
 	int _unused;
@@ -76,6 +78,10 @@ CC_VAR extern struct _GuiData {
 #else
 #define Gui_TouchUI false
 #endif
+
+/* This function is exposed because it was supposed to be used in the options menu.
+ * As it turns out, options don't change their minimum and maximum values when the window is resized. Why would they? */
+int Gui_GetMaxScale(void);
 
 float Gui_Scale(float value);
 float Gui_GetHotbarScale(void);

--- a/src/MenuOptions.c
+++ b/src/MenuOptions.c
@@ -832,13 +832,6 @@ static void ChatOptionsScreen_SetScale(const cc_string* v, float* target, const 
 	Gui_LayoutAll();
 }
 
-static cc_bool ChO_GetAutoScaleChat(void) { return Gui.AutoScaleChat; }
-static void    ChO_SetAutoScaleChat(cc_bool v) {
-	Gui.AutoScaleChat = v;
-	Options_SetBool(OPT_CHAT_AUTO_SCALE, v);
-	Gui_LayoutAll();
-}
-
 static void ChO_GetChatScale(cc_string* v) { String_AppendFloat(v, Gui.RawChatScale, 1); }
 static void ChO_SetChatScale(const cc_string* v) { 
 	ChatOptionsScreen_SetScale(v, &Gui.RawChatScale, OPT_CHAT_SCALE); 
@@ -867,8 +860,6 @@ static void    ChO_SetClickable(cc_bool v) {
 static void ChatOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 	MenuOptionsScreen_BeginButtons(s);
 	{
-		MenuOptionsScreen_AddBool(s, "Scale with window",
-			ChO_GetAutoScaleChat, ChO_SetAutoScaleChat, NULL);
 		MenuOptionsScreen_AddNum(s, "Chat scale",
 			0.25f, 4.00f, 1,
 			ChO_GetChatScale,     ChO_SetChatScale, NULL);
@@ -933,9 +924,27 @@ static void    GuO_SetUseFont(cc_bool v) {
 	Event_RaiseVoid(&ChatEvents.FontChanged);
 }
 
+static cc_bool GuO_GetAutoScaleChat(void) { return Gui.AutoScaleChat; }
+static void    GuO_SetAutoScaleChat(cc_bool v) {
+	Gui.AutoScaleChat = v;
+	Options_SetBool(OPT_CHAT_AUTO_SCALE, v);
+	Gui_LayoutAll();
+}
+
+static void GuO_GetGlobalScale(cc_string* v) { String_AppendFloat(v, Gui.GlobalScale, 1); }
+static void GuO_SetGlobalScale(const cc_string* v) { 
+	ChatOptionsScreen_SetScale(v, &Gui.GlobalScale, OPT_GUI_SCALE); 
+}
+
 static void GuiOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 	MenuOptionsScreen_BeginButtons(s);
 	{
+		/* In practice, it's limited to the maximum that fits in the window.
+		 * I couldn't make it work correctly here, so hardcoded limit for now. */
+		MenuOptionsScreen_AddNum(s,  "GUI scale",
+			1.00f, 4.00f, 2,
+			GuO_GetGlobalScale, GuO_SetGlobalScale, NULL);
+
 		MenuOptionsScreen_AddBool(s, "Show FPS",
 			GuO_GetShowFPS,   GuO_SetShowFPS, NULL);
 		MenuOptionsScreen_AddNum(s,  "Hotbar scale",
@@ -947,6 +956,9 @@ static void GuiOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 		MenuOptionsScreen_AddNum(s,  "Crosshair scale",
 			0.25f, 4.00f, 1,
 			GuO_GetCrosshair, GuO_SetCrosshair, NULL);
+
+		MenuOptionsScreen_AddBool(s, "Scale with window",
+			GuO_GetAutoScaleChat, GuO_SetAutoScaleChat, NULL);
 		
 		MenuOptionsScreen_AddBool(s, "Black text shadows",
 			GuO_GetShadows,   GuO_SetShadows, NULL);

--- a/src/Options.h
+++ b/src/Options.h
@@ -54,6 +54,7 @@ Copyright 2014-2025 ClassiCube | Licensed under BSD-3
 #define OPT_CHAT_SCALE "gui-chatscale"
 #define OPT_CHAT_AUTO_SCALE "gui-autoscalechat"
 #define OPT_CROSSHAIR_SCALE "gui-crosshairscale"
+#define OPT_GUI_SCALE "gui-globalscale"
 #define OPT_SHOW_FPS "gui-showfps"
 #define OPT_FONT_NAME "gui-fontname"
 #define OPT_BLACK_TEXT "gui-blacktextshadows"


### PR DESCRIPTION
Automatic scaling, which could previously only be disabled for the chat window, can now be disabled globally. A global scale factor option (scale relative to GUI texture pixel scale) is made available, and is set to 2.0 by default to emulate Minecraft behavior.

Adds options:
- GUI scale (baseline scale for all HUD elements when automatic scaling is disabled)

Moves options:
- "Scale with window" from "Chat" (`ChO_GetAutoScaleChat`, `ChO_SetAutoScaleChat`) to "GUI" (`GuO_GetAutoScaleChat`, `GuO_SetAutoScaleChat`)

The purpose of this contribution is to make it easier for players to play in fullscreen with a consistently sized GUI similar to the GUI from Classic-era Minecraft.