### PR TITLE
Symbian: Fix Socket_GetLastError

### DIFF
--- a/src/Audio.h
+++ b/src/Audio.h
@@ -16,7 +16,7 @@ struct AudioContext;
 	#define DEFAULT_SOUNDS_VOLUME 100
 #endif
 
-#ifdef CC_BUILD_NOMUSIC
+#if defined CC_BUILD_NOMUSIC || defined CC_BUILD_SYMBIAN
 	#define DEFAULT_MUSIC_VOLUME   0
 #else
 	#define DEFAULT_MUSIC_VOLUME 100

--- a/src/symbian/Platform_Symbian.cpp
+++ b/src/symbian/Platform_Symbian.cpp
@@ -589,7 +589,7 @@ cc_result Socket_Poll(cc_socket s, int timeoutMS, int mode, cc_bool* success) {
 }
 
 cc_result Socket_GetLastError(cc_socket s) {
-	int error = ERR_INVALID_ARGUMENT;
+	int error = 0;
 	socklen_t errSize = sizeof(error);
 
 	/* https://stackoverflow.com/questions/29479953/so-error-value-after-successful-socket-operation */


### PR DESCRIPTION
Fixed multiplayer on Symbian, also set music volume to 0 by default, so people won't have to disable it manually