### PR TITLE
Use multithreading on make and bump artifact-upload to v7

### DIFF
--- a/.github/actions/upload_build/action.yml
+++ b/.github/actions/upload_build/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.DEST_NAME }}
         path: ${{ inputs.SOURCE_FILE }}

--- a/.github/workflows/build_3ds.yml
+++ b/.github/workflows/build_3ds.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Compile 3DS build
         run: |
-          make 3ds
+          make 3ds -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_dreamcast.yml
+++ b/.github/workflows/build_dreamcast.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           export PATH=/opt/toolchains/dc/kos/utils/:$PATH
           source /opt/toolchains/dc/kos/environ.sh
-          make dreamcast
+          make dreamcast -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_gba.yml
+++ b/.github/workflows/build_gba.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Compile GBA build
         run: |
-          make gba
+          make gba -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_gc.yml
+++ b/.github/workflows/build_gc.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Compile GameCube build
         run: |
-          make gamecube
+          make gamecube -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Compile iOS build
         run: |
-          make ios
+          make ios -j $(nproc)
 
 #      - name: Compile iOS simulator build
 #        run: |

--- a/.github/workflows/build_macclassic.yml
+++ b/.github/workflows/build_macclassic.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v5
       - name: Compile Mac classic build
         run: |
-          make macclassic_ppc RETRO68=/Retro68-build/toolchain
-          make macclassic_68k RETRO68=/Retro68-build/toolchain
-          make macclassic_68k RETRO68=/Retro68-build/toolchain ARCH_68040=1
+          make macclassic_ppc RETRO68=/Retro68-build/toolchain -j $(nproc)
+          make macclassic_68k RETRO68=/Retro68-build/toolchain -j $(nproc)
+          make macclassic_68k RETRO68=/Retro68-build/toolchain ARCH_68040=1 -j $(nproc)
 
 
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_msdos.yml
+++ b/.github/workflows/build_msdos.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Compile MS dos build
         run: |
-          make CC=gcc dos
+          make CC=gcc dos -j $(nproc)
 
 
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_n64.yml
+++ b/.github/workflows/build_n64.yml
@@ -33,7 +33,7 @@ jobs:
           make install
           make tools-install
           cd $REAL_DIR
-          make n64
+          make n64 -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_n64.yml
+++ b/.github/workflows/build_n64.yml
@@ -30,8 +30,8 @@ jobs:
           cd /tmp
           git clone -b preview https://github.com/DragonMinded/libdragon.git --depth=1
           cd libdragon
-          make install
-          make tools-install
+          make install -j $(nproc)
+          make tools-install -j $(nproc)
           cd $REAL_DIR
           make n64 -j $(nproc)
           

--- a/.github/workflows/build_nds.yml
+++ b/.github/workflows/build_nds.yml
@@ -26,9 +26,9 @@ jobs:
 
       - name: Compile NDS build
         run: |
-          make ds
+          make ds -j $(nproc)
           export BUILD_NONET=1
-          make ds
+          make ds -j $(nproc)
  
          
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_ps1.yml
+++ b/.github/workflows/build_ps1.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Compile PS1 build
         run: |
           export PSN00BSDK_ROOT=/usr/local/psnoob
-          make ps1
+          make ps1 -j $(nproc)
 
 
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_ps2.yml
+++ b/.github/workflows/build_ps2.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Compile PS2 build
         run: |
-          make ps2
+          make ps2 -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_ps3.yml
+++ b/.github/workflows/build_ps3.yml
@@ -30,7 +30,7 @@ jobs:
           export PSL1GHT=/usr/local/ps3dev
           export PATH=$PATH:$PS3DEV/bin
           export PATH=$PATH:$PS3DEV/ppu/bin
-          make ps3
+          make ps3 -j $(nproc)
 
 
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_psp.yml
+++ b/.github/workflows/build_psp.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Compile PSP build
         run: |
-          make psp
+          make psp -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_saturn.yml
+++ b/.github/workflows/build_saturn.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Compile Saturn build
         run: |
-          make saturn
+          make saturn -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_switch.yml
+++ b/.github/workflows/build_switch.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Compile Switch build
         run: |
-          make switch
+          make switch -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_vita.yml
+++ b/.github/workflows/build_vita.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Compile Vita build
         run: |
-          make vita
+          make vita -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_wii.yml
+++ b/.github/workflows/build_wii.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Compile Wii build
         run: |
-          make wii
+          make wii -j $(nproc)
           
       - name: Create Wii homebrew
         run: |

--- a/.github/workflows/build_wiiu.yml
+++ b/.github/workflows/build_wiiu.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Compile Wii U build
         run: |
-          make wiiu
+          make wiiu -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_xbox.yml
+++ b/.github/workflows/build_xbox.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Compile Xbox build
         run: |
           eval $(/usr/src/nxdk/bin/activate -s)
-          make xbox
+          make xbox -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build

--- a/.github/workflows/build_xbox360.yml
+++ b/.github/workflows/build_xbox360.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           export DEVKITXENON=/usr/local/xenon
           export PATH=$PATH:$DEVKITXENON/bin:$DEVKITXENON/usr/bin
-          make xbox360
+          make xbox360 -j $(nproc)
           
           
       - uses: ./.github/actions/upload_build


### PR DESCRIPTION
These changes to workflows should make use of multi-threading to speed up compile time of the platform builds that use make, especially on consoles like N64, Dreamcast, Wii, etc.
```bash
make <platform> -j $(nproc)
```

Also bump artifact-upload to v7 to meet GitHub recommendation because of GitHub depreciation of Node 20 which v4 of upload-artifact used.

<img width="1000" height="600" alt="before" src="https://github.com/user-attachments/assets/2e1fdfac-9d4e-4af1-a166-02ab26d96843" />

<img width="1000" height="600" alt="after" src="https://github.com/user-attachments/assets/93313687-9daa-418d-aff5-7bd381da20ca" />