### PR TITLE
Commands: Add Commands_Unregister API

### DIFF
--- a/src/Commands.c
+++ b/src/Commands.c
@@ -28,6 +28,11 @@ void Commands_Register(struct ChatCommand* cmd) {
 	LinkedList_Append(cmd, cmds_head, cmds_tail);
 }
 
+void Commands_Unregister(struct ChatCommand* cmd) {
+	struct ChatCommand* cur;
+	LinkedList_Remove(cmd, cur, cmds_head, cmds_tail);
+}
+
 
 /*########################################################################################################################*
 *------------------------------------------------------Command handling---------------------------------------------------*

--- a/src/Commands.h
+++ b/src/Commands.h
@@ -31,5 +31,11 @@ struct ChatCommand {
 CC_API  void Commands_Register(      struct ChatCommand* cmd);
 typedef void (*FP_Commands_Register)(struct ChatCommand* cmd);
 
+/* Unregisters a previously registered client-side command. Pass the same
+   struct ChatCommand* that was given to Commands_Register. Safe to call on
+   a command that was never registered (no-op). */
+CC_API  void Commands_Unregister(      struct ChatCommand* cmd);
+typedef void (*FP_Commands_Unregister)(struct ChatCommand* cmd);
+
 CC_END_HEADER
 #endif


### PR DESCRIPTION
Allows plugins to remove a previously registered chat command from the global cmds_head linked list.