### PR TITLE
fix: reject NUL codepoint in keypress handler and input char validation

### DIFF
--- a/src/Gui.c
+++ b/src/Gui.c
@@ -693,8 +693,9 @@ static void OnFontChanged(void* obj) { Gui_RefreshAll(); }
 
 static void OnKeyPress(void* obj, int cp) {
 	struct Screen* s;
-	int i; 
+	int i;
 	char c;
+	if (!cp) return; /* ignore NUL keypress events (some Ctrl combos on X11) */
 	if (!Convert_TryCodepointToCP437(cp, &c)) return;
 
 	for (i = 0; i < Gui.ScreensCount; i++) 

--- a/src/Widgets.c
+++ b/src/Widgets.c
@@ -1242,6 +1242,7 @@ void InputWidget_Clear(struct InputWidget* w) {
 }
 
 static cc_bool InputWidget_AllowedChar(void* widget, char c) {
+	if (!c) return false; /* never allow NUL into the text buffer */
 	return Server.SupportsFullCP437 || (Convert_CP437ToUnicode(c) == c);
 }
 


### PR DESCRIPTION
<kbd>Ctrl</kbd>+<kbd>Space</kbd> (and <kbd>Ctrl</kbd>+<kbd>@</kbd> / <kbd>Ctrl</kbd>+<kbd>2</kbd>) on X11 makes Xlib's key lookup return an
ASCII NUL byte -- the standard <kbd>Ctrl</kbd>+<kbd>Space</kbd> = `^@` = NUL mapping -- which is raised as a character press event with codepoint `0`.
