### PR TITLE
Improve word navigation and deletion in chat text input

### DIFF
--- a/src/String.c
+++ b/src/String.c
@@ -1009,12 +1009,14 @@ void WordWrap_GetCoords(int index, const cc_string* lines, int numLines, int* co
 int WordWrap_GetBackLength(const cc_string* text, int index) {
 	int start = index;
 	if (index <= 0) return 0;
-	if (index >= text->length) Process_Abort("WordWrap_GetBackLength - index past end of string");
-	
-	/* Go backward to the end of the previous word */
-	while (index > 0 && text->buffer[index] == ' ') index--;
-	/* Go backward to the start of the current word */
-	while (index > 0 && text->buffer[index] != ' ') index--;
+	if (index > text->length) Process_Abort("WordWrap_GetBackLength - index past end of string");
+
+	index--; /* Move to the character to the left of the caret */
+	/* Skip over any spaces between the caret and the previous word */
+	while (index >= 0 && text->buffer[index] == ' ') index--;
+	/* Skip backward over the word, landing on its first character */
+	while (index >= 0 && text->buffer[index] != ' ') index--;
+	index++;
 
 	return start - index;
 }
@@ -1022,12 +1024,12 @@ int WordWrap_GetBackLength(const cc_string* text, int index) {
 int WordWrap_GetForwardLength(const cc_string* text, int index) {
 	int start = index, length = text->length;
 	if (index == -1) return 0;
-	if (index >= text->length) Process_Abort("WordWrap_GetForwardLength - index past end of string");
+	if (index > text->length) Process_Abort("WordWrap_GetForwardLength - index past end of string");
 
-	/* Go forward to the end of the word 'index' is currently in */
-	while (index < length && text->buffer[index] != ' ') index++;
-	/* Go forward to the start of the next word after 'index' */
+	/* Skip over any spaces between the caret and the next word */
 	while (index < length && text->buffer[index] == ' ') index++;
+	/* Skip forward over the word, landing just past its last character */
+	while (index < length && text->buffer[index] != ' ') index++;
 
 	return index - start;
 }

--- a/src/String_.h
+++ b/src/String_.h
@@ -268,9 +268,9 @@ void StringsBuffer_Sort(struct StringsBuffer* buffer);
 void WordWrap_Do(STRING_REF cc_string* text, cc_string* lines, int numLines, int lineLen);
 /* Calculates the position of a raw index in the wrapped lines. */
 void WordWrap_GetCoords(int index, const cc_string* lines, int numLines, int* coordX, int* coordY);
-/* Returns number of characters from current character to end of previous word. */
+/* Returns number of characters from the caret to the start of the previous word. */
 int  WordWrap_GetBackLength(const cc_string* text, int index);
-/* Returns number of characters from current character to start of next word. */
+/* Returns number of characters from the caret to the end of the next word. */
 int  WordWrap_GetForwardLength(const cc_string* text, int index);
 
 CC_END_HEADER

--- a/src/Widgets.c
+++ b/src/Widgets.c
@@ -1294,26 +1294,20 @@ static void InputWidget_DeleteChar(struct InputWidget* w) {
 }
 
 static void InputWidget_BackspaceKey(struct InputWidget* w) {
-	int i, len;
+	int i, start, end;
 
 	if (Input_IsActionPressed()) {
-		if (w->caretPos == -1) { w->caretPos = w->text.length - 1; }
-		len = WordWrap_GetBackLength(&w->text, w->caretPos);
-		if (!len) return;
+		/* Ctrl+backspace deletes the word (and any spaces) to the left of the caret */
+		end   = w->caretPos == -1 ? w->text.length : w->caretPos;
+		start = end - WordWrap_GetBackLength(&w->text, end);
+		if (start >= end) return;
 
-		w->caretPos -= len;
-		if (w->caretPos < 0) { w->caretPos = 0; }
-
-		for (i = 0; i <= len; i++) {
-			String_DeleteAt(&w->text, w->caretPos);
+		for (i = start; i < end; i++) {
+			String_DeleteAt(&w->text, start);
 		}
 
+		w->caretPos = start;
 		if (w->caretPos >= w->text.length) { w->caretPos = -1; }
-		if (w->caretPos == -1 && w->text.length > 0) {
-			String_InsertAt(&w->text, w->text.length, ' ');
-		} else if (w->caretPos >= 0 && w->text.buffer[w->caretPos] != ' ') {
-			String_InsertAt(&w->text, w->caretPos, ' ');
-		}
 		InputWidget_UpdateText(w);
 	} else if (w->text.length > 0 && w->caretPos != 0) {
 		InputWidget_DeleteChar(w);
@@ -1322,7 +1316,21 @@ static void InputWidget_BackspaceKey(struct InputWidget* w) {
 }
 
 static void InputWidget_DeleteKey(struct InputWidget* w) {
-	if (w->text.length > 0 && w->caretPos != -1) {
+	int i, start, end;
+
+	if (Input_IsActionPressed()) {
+		/* Ctrl+delete deletes the word (and any spaces) to the right of the caret */
+		start = w->caretPos == -1 ? w->text.length : w->caretPos;
+		end   = start + WordWrap_GetForwardLength(&w->text, start);
+		if (start >= end) return;
+
+		for (i = start; i < end; i++) {
+			String_DeleteAt(&w->text, start);
+		}
+
+		if (w->caretPos >= w->text.length) { w->caretPos = -1; }
+		InputWidget_UpdateText(w);
+	} else if (w->text.length > 0 && w->caretPos != -1) {
 		String_DeleteAt(&w->text, w->caretPos);
 		if (w->caretPos >= w->text.length) { w->caretPos = -1; }
 		InputWidget_UpdateText(w);
@@ -1331,7 +1339,7 @@ static void InputWidget_DeleteKey(struct InputWidget* w) {
 
 static void InputWidget_LeftKey(struct InputWidget* w) {
 	if (Input_IsActionPressed()) {
-		if (w->caretPos == -1) { w->caretPos = w->text.length - 1; }
+		if (w->caretPos == -1) { w->caretPos = w->text.length; }
 		w->caretPos -= WordWrap_GetBackLength(&w->text, w->caretPos);
 		InputWidget_UpdateCaret(w);
 		return;


### PR DESCRIPTION
make chat text input editing similar to other text editors (Chrome, Firefox, VS Code, ...)

- <kbd>Ctrl</kbd>+<kbd>Delete</kbd> now deletes the word to the **right** of the caret
  - previously it only removed a single character, unlike <kbd>Ctrl</kbd>+<kbd>Backspace</kbd>
- <kbd>Ctrl</kbd>+<kbd>Backspace</kbd> now deletes the word to the **left** of the caret
  - previously it left a stray space behind after deleting
- <kbd>Ctrl</kbd>+<kbd>Left</kbd> / <kbd>Ctrl</kbd>+<kbd>Right</kbd> reuse the same caret-position word lengths
  - <kbd>Ctrl</kbd>+<kbd>Right</kbd> now stops at the **end** of a word rather than the start of the next
