### PR TITLE
Fix down arrow erasing typed text in chat input

### DIFF
--- a/src/Widgets.c
+++ b/src/Widgets.c
@@ -1939,7 +1939,7 @@ static void ChatInputWidget_DownKey(struct InputWidget* w) {
 		return;
 	}
 
-	if (!Chat_InputLog.count) return;
+	if (W->typingLogPos >= Chat_InputLog.count) return;
 	W->typingLogPos++;
 	w->text.length = 0;
 


### PR DESCRIPTION
Pressing the down arrow while editing chat (without having pressed up first)
erased the typed text. `ChatInputWidget_DownKey` unconditionally cleared
`w->text` and then restored `origStr`, but `origStr` is only populated by
`ChatInputWidget_UpKey` — so it was empty and the draft was lost.
