### PR TITLE
SSL: Fix default implementation of SSL_Write()

### DIFF
--- a/src/SSL.c
+++ b/src/SSL.c
@@ -258,7 +258,7 @@ cc_result SSL_Read(void* ctx, cc_uint8* data, cc_uint32 count, cc_uint32* read) 
 	return ERR_NOT_SUPPORTED; 
 }
 
-cc_result SSL_WriteAll(void* ctx, const cc_uint8* data, cc_uint32 count) { 
+cc_result SSL_Write(void* ctx, const cc_uint8* data, cc_uint32 count, cc_uint32* sent) {
 	return ERR_NOT_SUPPORTED; 
 }
 


### PR DESCRIPTION
The signature of `SSL_Write()` has changed in 9bd6ad7, but the default implementation still uses the old signature.
This causes ClassiCube to not compile with `CC_SSL_BACKEND=CC_SSL_BACKEND_NONE`.
I noticed this issue while updating my port of ClassiCube to our teaching operating system [hhuOS](https://github.com/hhuOS/hhuOS).

This PR just updates a single line in `SSL.c` to use the new function signature for `SSL_Write()`.

Old signature: `cc_result SSL_WriteAll(void* ctx, const cc_uint8* data, cc_uint32 count)`
New signature: `cc_result SSL_Write(void* ctx, const cc_uint8* data, cc_uint32 count, cc_uint32* sent)`