### PR TITLE
Add initial Snowsky Echo Disc (Ingenic X2000) support

### DIFF
--- a/misc/snowsky/Makefile
+++ b/misc/snowsky/Makefile
@@ -1,0 +1,31 @@
+# Build ClassiCube for the Snowsky Echo Disc (FiiO / Ingenic X2000).
+#
+# The device runs embedded Linux on a MIPS32r2 (little-endian, O32, NaN2008) core, so this
+# cross-compiles with zig (https://ziglang.org) acting as the C compiler + MIPS toolchain.
+# It reuses the POSIX platform layer and a software rasteriser (no GPU/GL on this device).
+#
+# Usage (from the repository root):
+#     make -f misc/snowsky/Makefile              # SoftGPU (default)
+#     make -f misc/snowsky/Makefile GFX=SOFTFP   # fixed-point rasteriser (no FPU reliance)
+#
+# See misc/snowsky/readme.md for how to deploy and run it on the device.
+
+TARGET  := ClassiCube-snowsky
+ZIG     ?= zig
+GFX     ?= SOFTGPU
+
+CFLAGS  := -target mipsel-linux-musleabi -static \
+           -march=mips32r2 -mabi=32 -mnan=2008 \
+           -O2 -fno-strict-aliasing \
+           -DPLAT_SNOWSKY -DCC_GFX_BACKEND=CC_GFX_BACKEND_$(GFX)
+LIBS    := -lm -lunwind
+
+$(TARGET): src/*.c
+	$(ZIG) cc $(CFLAGS) -o $@ src/*.c $(LIBS)
+	@# zig omits the NaN2008 ELF flag even with -mnan=2008; the device's kernel needs it.
+	python3 misc/snowsky/set_nan2008.py $@
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: clean

--- a/misc/snowsky/mq_decoy.c
+++ b/misc/snowsky/mq_decoy.c
@@ -1,0 +1,17 @@
+/* Placeholder process for run.sh.
+ *
+ * The stock firmware's supervisor (/usr/project/fiio_init.sh) relaunches the UI whenever
+ * `pgrep -x mq_ui` / `pgrep -x mq_player` fails - and that relaunch also kills wifi and blanks
+ * the backlight. run.sh keeps those checks passing by running two copies of this do-nothing
+ * program named mq_ui / mq_player, so the supervisor stays satisfied and never fights us.
+ *
+ * It just sleeps forever using no CPU. Build it with the same toolchain as the main binary:
+ *   zig cc -target mipsel-linux-musleabi -static -march=mips32r2 -mabi=32 -mnan=2008 \
+ *          -o mq_decoy misc/snowsky/mq_decoy.c && python3 misc/snowsky/set_nan2008.py mq_decoy
+ */
+#include <unistd.h>
+
+int main(void) {
+	for (;;) pause();
+	return 0;
+}

--- a/misc/snowsky/readme.md
+++ b/misc/snowsky/readme.md
@@ -1,0 +1,92 @@
+# ClassiCube on the Snowsky Echo Disc
+
+A port to the **Snowsky Echo Disc** (a FiiO music player): an Ingenic **X2000** SoC (MIPS32r2,
+little-endian) running embedded Linux, with a **360x360 round LCD** and a capacitive touchscreen.
+
+It reuses the POSIX platform layer and the software rasteriser (no GPU / OpenGL on this device).
+The device-specific part is a single windowing backend, `src/Window_Fbdev.c`, selected by the
+`PLAT_SNOWSKY` platform in `src/Core.h`:
+
+- **Display** - takes over the raw Linux framebuffer `/dev/fb0` and converts ClassiCube's 32bpp
+  bitmap to the panel's pixel format (read from the driver). The panel is mounted upside-down, so
+  output and input are rotated 180 by default (`CC_FB_ROTATE=0` disables it).
+- **Input** - standard Linux evdev, matched by device name: the physical buttons (`x2000_key`)
+  and the capacitive touchscreen (`cst816`).
+
+## Controls
+
+| Input | Action |
+|-------|--------|
+| Vol+ | Move forward (`W`) |
+| Vol- | Move back (`S`) |
+| Play/Pause | Action / place / break (left click) |
+| Power (short tap) | Jump (space) |
+| Touch drag (in game) | Look around |
+| Touch (in menus) | Move + click the pointer |
+
+## Building
+
+Requires [zig](https://ziglang.org) (used as the MIPS cross-compiler). From the repo root:
+
+```sh
+make -f misc/snowsky/Makefile               # SoftGPU rasteriser (default)
+make -f misc/snowsky/Makefile GFX=SOFTFP    # fixed-point rasteriser (if the FPU is a bottleneck)
+```
+
+This produces `ClassiCube-snowsky` and applies the NaN2008 ELF flag (the kernel requires it).
+Also build the watchdog decoy used by the launcher:
+
+```sh
+zig cc -target mipsel-linux-musleabi -static -march=mips32r2 -mabi=32 -mnan=2008 \
+       -o mq_decoy misc/snowsky/mq_decoy.c
+python3 misc/snowsky/set_nan2008.py mq_decoy
+```
+
+## Assets
+
+The device is offline-only here, so pre-stage the texture pack instead of letting the launcher
+download it:
+
+```sh
+curl -L http://static.classicube.net/default.zip -o default.zip
+```
+
+## Deploying and running
+
+Copy the binary, `default.zip` (into a `texpacks/` subfolder), `mq_decoy`, and `misc/snowsky/run.sh`
+onto the device, e.g. under `/usr/data/classicube`:
+
+```
+/usr/data/classicube/ClassiCube
+/usr/data/classicube/texpacks/default.zip
+/usr/data/classicube/mq_decoy
+/usr/data/classicube/run.sh
+```
+
+Then, from an interactive SSH session on the device:
+
+```sh
+sh /usr/data/classicube/run.sh
+```
+
+`run.sh` takes the device over from the stock firmware and is fully reversible - **Ctrl-C (or a
+reboot) restores the stock music-player UI**. It handles three things the firmware does to keep
+its UI running, which otherwise make a takeover impossible:
+
+1. **Hardware watchdog** - `mq_player` feeds a ~10s watchdog on `/dev/jz_watchdog`; killing it
+   makes the SoC hard-reset in a few seconds. `run.sh` feeds and stops it via the stock
+   `cmd_watchdog` tool.
+2. **Supervisor** - `/usr/project/fiio_init.sh` relaunches `mq_ui`/`mq_player` (and kills wifi and
+   blanks the backlight) whenever `pgrep -x mq_ui`/`mq_player` fails. `run.sh` keeps those checks
+   passing with harmless decoys named `mq_ui`/`mq_player` (see `mq_decoy.c`).
+3. **Framebuffer/input owner** - `mq_ui` owns `/dev/fb0` and the input devices, so it is stopped.
+
+## Notes
+
+- `Window_DrawFramebuffer` handles both 16bpp (RGB565) and 32bpp panels; the format is read from
+  the driver, so the same binary works regardless of how the panel is configured.
+- The evdev button codes in `Window_Fbdev.c` were found by reverse-engineering the stock
+  `mq_player`. If a different unit reports different codes, run with `CC_KEY_DEBUG=1` and it logs
+  every button's `code`/`down` state.
+- Only a *long* hardware hold of Power force-offs the device (handled by the PMU below Linux);
+  a short tap is just an evdev event, which is why it can be used to jump.

--- a/misc/snowsky/run.sh
+++ b/misc/snowsky/run.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Launch ClassiCube on the Snowsky Echo Disc, taking the device over from the stock firmware.
+# Run it from an INTERACTIVE ssh session on the device. It is fully reversible: Ctrl-C (or a
+# reboot) restores the stock music-player UI.
+#
+# Getting past the stock firmware needs three things handled at once:
+#   1. HARDWARE WATCHDOG - mq_player feeds a 10s watchdog on /dev/jz_watchdog; if we just kill it
+#      the SoC hard-resets. So we feed+stop it ourselves via the stock `cmd_watchdog` tool.
+#   2. SUPERVISOR - /usr/project/fiio_init.sh relaunches mq_ui/mq_player (and kills wifi + blanks
+#      the backlight) whenever `pgrep -x mq_ui`/`mq_player` fails. We keep those checks passing
+#      with harmless decoys named mq_ui/mq_player (busybox pgrep -x matches argv[0], so we launch
+#      the decoy binary via a PATH lookup of the bare name).
+#   3. FRAMEBUFFER/INPUT - mq_ui owns /dev/fb0 and the input devices, so it must be stopped.
+#
+# Layout expected on the device (adjust CC_DIR if you put it elsewhere):
+#   $CC_DIR/ClassiCube      the binary built by misc/snowsky/Makefile
+#   $CC_DIR/texpacks/default.zip   the texture pack (http://static.classicube.net/default.zip)
+#   $CC_DIR/mq_decoy        the decoy built from misc/snowsky/mq_decoy.c
+CC_DIR="${CC_DIR:-/usr/data/classicube}"
+DECOY_DIR=/usr/data/ccdecoy
+WD=/usr/bin/cmd_watchdog
+export LD_LIBRARY_PATH=/usr/lib:/usr/lib/pulseaudio:/usr/data/lib   # for cmd_watchdog (libhardware2.so)
+
+DU=""; DP=""; REAPER=""
+
+cleanup() {
+	echo "[cc] restoring stock UI ..."
+	[ -n "$REAPER" ] && kill -9 "$REAPER" 2>/dev/null
+	[ -n "$DU" ]     && kill -9 "$DU" 2>/dev/null
+	[ -n "$DP" ]     && kill -9 "$DP" 2>/dev/null
+	rm -rf "$DECOY_DIR" 2>/dev/null
+	sleep 1
+	/usr/project/fiio_init.sh >/dev/null 2>&1 &   # brings back the UI and re-arms the watchdog feed
+}
+trap cleanup INT TERM EXIT
+
+[ -s "$CC_DIR/mq_decoy" ] || { echo "[cc] ERROR: $CC_DIR/mq_decoy missing"; exit 1; }
+
+# 1. decoys: run the do-nothing binary as "mq_ui" / "mq_player" (argv[0] via PATH lookup)
+mkdir -p "$DECOY_DIR"
+cp "$CC_DIR/mq_decoy" "$DECOY_DIR/mq_ui"
+cp "$CC_DIR/mq_decoy" "$DECOY_DIR/mq_player"
+chmod 755 "$DECOY_DIR/mq_ui" "$DECOY_DIR/mq_player"
+PATH="$DECOY_DIR:$PATH" mq_ui &
+DU=$!
+PATH="$DECOY_DIR:$PATH" mq_player &
+DP=$!
+sleep 1
+
+# 2+3. reaper: every second, kill the supervisor watchdog + the real mq_ui/mq_player (never the
+#      decoys), and keep the hardware watchdog handled.
+( while :; do
+	for d in /proc/[0-9]*; do
+		pid=${d#/proc/}
+		[ "$pid" = "$DU" ] && continue
+		[ "$pid" = "$DP" ] && continue
+		c=$(cat "$d/cmdline" 2>/dev/null | tr '\0' ' ')
+		case "$c" in *fiio_init.sh*) kill -9 "$pid" 2>/dev/null; continue ;; esac
+		case "$(cat "$d/comm" 2>/dev/null)" in mq_ui|mq_player) kill -9 "$pid" 2>/dev/null ;; esac
+	done
+	"$WD" feed >/dev/null 2>&1     # keep the hardware watchdog alive this cycle ...
+	"$WD" stop >/dev/null 2>&1     # ... and disarm it if the driver allows
+	sleep 1
+  done ) &
+REAPER=$!
+sleep 2   # let the reaper clear mq_ui and neutralise the watchdog before we take the screen
+
+# backlight on (the supervisor may have blanked it)
+for b in /sys/class/backlight/*/brightness; do
+	[ -e "$b" ] || continue
+	m=$(cat "$(dirname "$b")/max_brightness" 2>/dev/null || echo 255)
+	echo "$m" > "$b" 2>/dev/null
+done
+
+cd "$CC_DIR" || { echo "[cc] ERROR: $CC_DIR missing"; exit 1; }
+chmod 755 ./ClassiCube 2>/dev/null
+echo "[cc] launching ClassiCube (Ctrl-C to quit / restore stock UI)"
+./ClassiCube

--- a/misc/snowsky/set_nan2008.py
+++ b/misc/snowsky/set_nan2008.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Sets the NaN2008 flag (EF_MIPS_NAN2008, 0x400) in a MIPS ELF's e_flags.
+# zig cc omits it even with -mnan=2008, but the Snowsky's kernel requires it.
+import sys
+from pathlib import Path
+
+p = Path(sys.argv[1])
+d = bytearray(p.read_bytes())
+if d[:4] != b"\x7fELF" or d[4] != 1 or d[5] != 1:
+    raise SystemExit("not a 32-bit little-endian ELF")
+old = int.from_bytes(d[0x24:0x28], "little")
+new = old | 0x400
+d[0x24:0x28] = new.to_bytes(4, "little")
+p.write_bytes(d)
+print(f"{p.name}: e_flags 0x{old:08x} -> 0x{new:08x}")

--- a/src/Core.h
+++ b/src/Core.h
@@ -143,6 +143,7 @@ typedef cc_uint8  cc_bool;
 #define CC_WIN_BACKEND_WIN32    5
 #define CC_WIN_BACKEND_COCOA    6
 #define CC_WIN_BACKEND_BEOS     7
+#define CC_WIN_BACKEND_FBDEV    8
 #define CC_WIN_BACKEND_WIN32CE  9
 
 #define CC_GFX_BACKEND_SOFTGPU   1
@@ -309,6 +310,22 @@ typedef cc_uint8  cc_bool;
 	#define DEFAULT_AUD_BACKEND CC_AUD_BACKEND_NULL
 	#define DEFAULT_NET_BACKEND CC_NET_BACKEND_BUILTIN
 	#define DEFAULT_GFX_BACKEND CC_GFX_BACKEND_SOFTMIN
+#elif defined PLAT_SNOWSKY
+	/* Snowsky Echo Disc (FiiO) - Ingenic X2000, raw Linux framebuffer + evdev input.
+	   Offline single-player build: no freetype (bitmap font from the texture pack), no
+	   resource downloader (assets are pre-staged), no networking. Software rendering. */
+	#define CC_BUILD_LINUX
+	#define CC_BUILD_POSIX
+	#undef  CC_BUILD_FREETYPE
+	#undef  CC_BUILD_RESOURCES
+	#undef  CC_BUILD_PLUGINS
+	/* Networking stays compiled (Platform_Posix's socket layer needs it), but with no SSL
+	   so nothing external is required; the PoC is offline single-player regardless. */
+	#define DEFAULT_NET_BACKEND CC_NET_BACKEND_BUILTIN
+	#define DEFAULT_SSL_BACKEND CC_SSL_BACKEND_NONE
+	#define DEFAULT_AUD_BACKEND CC_AUD_BACKEND_NULL
+	#define DEFAULT_GFX_BACKEND CC_GFX_BACKEND_SOFTGPU
+	#define DEFAULT_WIN_BACKEND CC_WIN_BACKEND_FBDEV
 #elif defined __linux__
 	#define CC_BUILD_LINUX
 	#define CC_BUILD_POSIX

--- a/src/Platform_Posix.c
+++ b/src/Platform_Posix.c
@@ -448,7 +448,12 @@ void Thread_Run(void** handle, Thread_StartFunc func, int stackSize, const char*
 	if (res) Process_Abort2(res, "Creating thread");
 	pthread_attr_destroy(&attrs);
 	
-#if defined CC_BUILD_LINUX
+#if defined CC_BUILD_LINUX && defined PLAT_SNOWSKY
+	/* Static musl build: dlsym(RTLD_NEXT, ...) has no dynamic linker to walk and
+	   crashes. musl has always provided pthread_setname_np, so call it directly. */
+	extern int pthread_setname_np(pthread_t thread, const char* name);
+	pthread_setname_np(*ptr, name);
+#elif defined CC_BUILD_LINUX
 	static int (*FP_pthread_setname_np)(pthread_t thread, const char* name);
 	/* Not available on old libc versions, so load it dynamically */
 	if (!FP_pthread_setname_np) {

--- a/src/Window_Fbdev.c
+++ b/src/Window_Fbdev.c
@@ -1,0 +1,389 @@
+#include "Core.h"
+#if CC_WIN_BACKEND == CC_WIN_BACKEND_FBDEV
+/*
+Windowing backend for the Snowsky Echo Disc (FiiO / Ingenic X2000), a 360x360 round-LCD
+music player running embedded Linux. Pairs with the software rasteriser (SoftGPU/SoftFP).
+
+Display: takes over the raw Linux framebuffer (/dev/fb0), single-buffered. ClassiCube
+         renders into its 32bpp BGRA bitmap; Window_DrawFramebuffer converts that to the
+         panel's pixel format (16bpp RGB565 or 32bpp), read from the driver at runtime.
+         The panel is mounted upside-down, so output+input are rotated 180 by default.
+Input  : all input is standard Linux evdev (/dev/input/eventN), matched by device name:
+         - the physical buttons  ("x2000_key")  -> movement / action / jump
+         - the capacitive touch  ("cst816")     -> pointer + click, and drag-to-look in 3D
+
+NOTE: the stock UI (mq_ui/mq_player) owns /dev/fb0 and the input devices and is kept alive
+      by a supervisor + hardware watchdog, so it must be stopped first (see misc/snowsky).
+*/
+#include "_WindowBase.h"
+#include "String_.h"
+#include "Funcs.h"
+#include "Bitmap.h"
+#include "Errors.h"
+#include "Utils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <linux/fb.h>
+#include <linux/input.h>
+
+/* single-screen device: the alternate window mirrors the main window */
+struct cc_window Window_Alt;
+
+static int EnvInt(const char* name, int fallback) {
+	const char* v = getenv(name);
+	return (v && *v) ? (int)strtol(v, NULL, 0) : fallback;
+}
+
+
+/*########################################################################################################################*
+*--------------------------------------------------------Framebuffer------------------------------------------------------*
+*#########################################################################################################################*/
+static int      fb_fd = -1;
+static cc_uint8* fb_mem;       /* mmap'd visible buffer */
+static long     fb_memlen;
+static int      fb_stride;     /* bytes per scanline (finfo.line_length) */
+static int      fb_bpp;        /* bits per pixel (16 or 32, from the driver) */
+static int      scr_w, scr_h;
+static int      fb_rotate = 180; /* panel is mounted upside-down; 0 or 180 (env CC_FB_ROTATE) */
+/* pixel bitfield layout, straight from FBIOGET_VSCREENINFO */
+static int      r_off, r_len, g_off, g_len, b_off, b_len;
+
+static void InitFramebuffer(void) {
+	struct fb_var_screeninfo vinfo;
+	struct fb_fix_screeninfo finfo;
+
+	fb_fd = open("/dev/fb0", O_RDWR);
+	if (fb_fd < 0) Process_Abort2(errno, "Failed to open /dev/fb0");
+
+	if (ioctl(fb_fd, FBIOGET_FSCREENINFO, &finfo) < 0)
+		Process_Abort2(errno, "FBIOGET_FSCREENINFO failed");
+	if (ioctl(fb_fd, FBIOGET_VSCREENINFO, &vinfo) < 0)
+		Process_Abort2(errno, "FBIOGET_VSCREENINFO failed");
+
+	scr_w     = vinfo.xres;
+	scr_h     = vinfo.yres;
+	fb_bpp    = vinfo.bits_per_pixel;
+	fb_stride = finfo.line_length;
+	fb_memlen = finfo.smem_len;
+
+	r_off = vinfo.red.offset;    r_len = vinfo.red.length;
+	g_off = vinfo.green.offset;  g_len = vinfo.green.length;
+	b_off = vinfo.blue.offset;   b_len = vinfo.blue.length;
+
+	fb_mem = (cc_uint8*)mmap(NULL, fb_memlen, PROT_READ | PROT_WRITE, MAP_SHARED, fb_fd, 0);
+	if (fb_mem == MAP_FAILED) Process_Abort2(errno, "Failed to mmap /dev/fb0");
+
+	Platform_Log4("FB %ix%i, %i bpp, stride %i", &scr_w, &scr_h, &fb_bpp, &fb_stride);
+}
+
+void Window_AllocFramebuffer(struct Bitmap* bmp, int width, int height) {
+	bmp->scan0  = (BitmapCol*)Mem_Alloc(width * height, BITMAPCOLOR_SIZE, "window pixels");
+	bmp->width  = width;
+	bmp->height = height;
+}
+
+void Window_FreeFramebuffer(struct Bitmap* bmp) {
+	Mem_Free(bmp->scan0);
+}
+
+/* Packs an 8-bit-per-channel colour into the panel's native pixel using its bitfields */
+static CC_INLINE cc_uint32 PackPixel(BitmapCol c) {
+	cc_uint32 R = BitmapCol_R(c) >> (8 - r_len);
+	cc_uint32 G = BitmapCol_G(c) >> (8 - g_len);
+	cc_uint32 B = BitmapCol_B(c) >> (8 - b_len);
+	return (R << r_off) | (G << g_off) | (B << b_off);
+}
+
+void Window_DrawFramebuffer(Rect2D r, struct Bitmap* bmp) {
+	int x0 = r.x, y0 = r.y;
+	int x1 = r.x + r.width, y1 = r.y + r.height;
+	int x, y;
+
+	if (x0 < 0) x0 = 0;
+	if (y0 < 0) y0 = 0;
+	if (x1 > scr_w)       x1 = scr_w;
+	if (x1 > bmp->width)  x1 = bmp->width;
+	if (y1 > scr_h)       y1 = scr_h;
+	if (y1 > bmp->height) y1 = bmp->height;
+
+	for (y = y0; y < y1; y++) {
+		int dy = (fb_rotate == 180) ? (scr_h - 1 - y) : y;
+		BitmapCol* src = Bitmap_GetRow(bmp, y);
+		if (fb_bpp == 32) {
+			cc_uint32* dst = (cc_uint32*)(fb_mem + (cc_uintptr)dy * fb_stride);
+			if (fb_rotate == 180) { for (x = x0; x < x1; x++) dst[scr_w - 1 - x] = PackPixel(src[x]); }
+			else                  { for (x = x0; x < x1; x++) dst[x]             = PackPixel(src[x]); }
+		} else if (fb_bpp == 16) {
+			cc_uint16* dst = (cc_uint16*)(fb_mem + (cc_uintptr)dy * fb_stride);
+			if (fb_rotate == 180) { for (x = x0; x < x1; x++) dst[scr_w - 1 - x] = (cc_uint16)PackPixel(src[x]); }
+			else                  { for (x = x0; x < x1; x++) dst[x]             = (cc_uint16)PackPixel(src[x]); }
+		}
+	}
+}
+
+
+/*########################################################################################################################*
+*------------------------------------------------------Input (evdev)------------------------------------------------------*
+*#########################################################################################################################*/
+/* Opens the /dev/input/eventN device whose name contains `match` (non-blocking, grabbed). */
+static int OpenEvdev(const char* match) {
+	char path[32], name[128];
+	int i, fd;
+
+	for (i = 0; i < 32; i++) {
+		snprintf(path, sizeof(path), "/dev/input/event%i", i);
+		fd = open(path, O_RDONLY | O_NONBLOCK);
+		if (fd < 0) continue;
+
+		name[0] = '\0';
+		if (ioctl(fd, EVIOCGNAME(sizeof(name)), name) >= 0 && strstr(name, match)) {
+			ioctl(fd, EVIOCGRAB, (void*)1); /* take input from the (now stopped) stock UI */
+			Platform_Log2("input: %c (event%i)", name, &i);
+			return fd;
+		}
+		close(fd);
+	}
+	Platform_Log1("input: '%c' not found", match);
+	return -1;
+}
+
+/*------------------------------------------------------ Buttons -----------------------------------------------------------*/
+/* The physical buttons are exposed by the "x2000_key" evdev device as ordinary EV_KEY events
+   (value 1=press, 2=repeat, 0=release). Codes are vendor specific (found by reverse
+   engineering mq_player); set CC_KEY_DEBUG=1 to log codes when porting to another unit. */
+/* evdev codes reported by the x2000_key device (prefixed to avoid clashing with the KEY_*
+   names in <linux/input-event-codes.h>). Each physical button reports two codes except
+   Play/Pause. The volume buttons auto-repeat while held; Power is a momentary tap. */
+#define SK_FWD_A     263  /* Vol+       -> move forward (W)         */
+#define SK_FWD_B     251
+#define SK_BACK_A    262  /* Vol-       -> move back    (S)         */
+#define SK_BACK_B    267
+#define SK_PLAY      250  /* Play/Pause -> action      (left click) */
+#define SK_JUMP_A    265  /* Power      -> jump        (space)      */
+#define SK_JUMP_B    259
+#define JUMP_HOLD 0.15f    /* how long to latch a jump for a momentary Power tap */
+
+static int   key_fd  = -1;     /* x2000_key evdev node */
+static int   gate_fd = -1;     /* /dev/key_ioctl: opened as a prerequisite, never read */
+static int   key_debug;
+static float jump_hold;        /* remaining latched-jump time; <=0 = released */
+static cc_uint8 btn_down[288]; /* evdev code -> current pressed state (codes are 250..267) */
+
+static void InitButtons(void) {
+	key_debug = EnvInt("CC_KEY_DEBUG", 0);
+	/* The stock UI opens this char device (O_RDWR) and holds it; the kernel appears to gate
+	   button reporting on it, so open + hold it too. The events come from evdev, not here. */
+	gate_fd = open("/dev/key_ioctl", O_RDWR);
+	key_fd  = OpenEvdev("x2000_key");
+}
+
+static void ProcessButtons(float delta) {
+	struct input_event ev;
+	int down;
+	if (key_fd < 0) return;
+
+	while (read(key_fd, &ev, sizeof(ev)) == sizeof(ev)) {
+		if (ev.type != EV_KEY) continue;
+		down = ev.value != 0;   /* press(1) / repeat(2) -> down, release(0) -> up */
+		if (key_debug) { int code = ev.code; Platform_Log2("key code=%i down=%i", &code, &down); }
+		if (ev.code < 288) btn_down[ev.code] = (cc_uint8)down;
+
+		switch (ev.code) {
+		case SK_PLAY:    Input_SetNonRepeatable(CCMOUSE_L, down); break;  /* action = left click */
+		/* Power is momentary (press+release in one frame, no auto-repeat), so latch the jump key
+		   held for a moment on press, otherwise a tap is over before a physics tick sees it. */
+		case SK_JUMP_A:
+		case SK_JUMP_B:  if (down) { Input_SetPressed(CCKEY_SPACE); jump_hold = JUMP_HOLD; } break;
+		}
+	}
+
+	/* Vol+/Vol- each report two codes and auto-repeat while held; OR their states so the
+	   movement key stays pressed for the whole hold and releases cleanly (no coast/stutter). */
+	Input_Set(CCKEY_W, btn_down[SK_FWD_A]  | btn_down[SK_FWD_B]);
+	Input_Set(CCKEY_S, btn_down[SK_BACK_A] | btn_down[SK_BACK_B]);
+
+	if (jump_hold > 0.0f) { jump_hold -= delta; if (jump_hold <= 0.0f) Input_SetReleased(CCKEY_SPACE); }
+}
+
+/*------------------------------------------------------ Touchscreen ------------------------------------------------------*/
+static int ts_fd = -1;
+static int ts_minx, ts_maxx, ts_miny, ts_maxy;
+static int rawX, rawY;            /* latest raw ABS values          */
+static int touchX, touchY;        /* mapped to screen pixels        */
+static int touching;              /* finger currently down          */
+static int lookHasPrev;           /* have a previous point for look */
+static int lookPrevX, lookPrevY;
+
+static void ReadAbsRange(int axis, int* lo, int* hi) {
+	struct input_absinfo abs;
+	*lo = 0; *hi = 0;
+	if (ioctl(ts_fd, EVIOCGABS(axis), &abs) >= 0) { *lo = abs.minimum; *hi = abs.maximum; }
+}
+
+static void InitTouch(void) {
+	ts_fd = OpenEvdev("cst816");
+	if (ts_fd < 0) return;
+
+	ReadAbsRange(ABS_X, &ts_minx, &ts_maxx);
+	ReadAbsRange(ABS_Y, &ts_miny, &ts_maxy);
+	if (ts_maxx <= ts_minx) { ts_minx = 0; ts_maxx = scr_w - 1; }
+	if (ts_maxy <= ts_miny) { ts_miny = 0; ts_maxy = scr_h - 1; }
+}
+
+static int MapAxis(int raw, int lo, int hi, int size) {
+	int v;
+	if (hi <= lo) return 0;
+	v = (raw - lo) * (size - 1) / (hi - lo);
+	if (v < 0) v = 0;
+	if (v >= size) v = size - 1;
+	return v;
+}
+
+static void TouchCommit(void) {
+	touchX = MapAxis(rawX, ts_minx, ts_maxx, scr_w);
+	touchY = MapAxis(rawY, ts_miny, ts_maxy, scr_h);
+	if (fb_rotate == 180) { touchX = scr_w - 1 - touchX; touchY = scr_h - 1 - touchY; }
+
+	if (Input.RawMode) {
+		/* in-game: drag to look. Feed relative motion, no jump on initial contact. */
+		if (touching && lookHasPrev) {
+			int dx = touchX - lookPrevX, dy = touchY - lookPrevY;
+			if (dx || dy) Event_RaiseRawMove(&PointerEvents.RawMoved, (float)dx, (float)dy);
+		}
+		lookPrevX = touchX; lookPrevY = touchY;
+		lookHasPrev = touching;
+	} else {
+		/* menus/launcher: emulate a mouse pointer + left click */
+		Pointer_SetPosition(0, touchX, touchY);
+	}
+}
+
+static void ProcessTouch(void) {
+	struct input_event ev;
+	if (ts_fd < 0) return;
+
+	while (read(ts_fd, &ev, sizeof(ev)) == sizeof(ev)) {
+		switch (ev.type) {
+		case EV_ABS:
+			if (ev.code == ABS_X || ev.code == ABS_MT_POSITION_X) rawX = ev.value;
+			if (ev.code == ABS_Y || ev.code == ABS_MT_POSITION_Y) rawY = ev.value;
+			break;
+		case EV_KEY:
+			if (ev.code == BTN_TOUCH) {
+				touching = ev.value;
+				if (!touching) lookHasPrev = false;
+				if (!Input.RawMode) Input_SetNonRepeatable(CCMOUSE_L, touching);
+			}
+			break;
+		case EV_SYN:
+			if (ev.code == SYN_REPORT) TouchCommit();
+			break;
+		}
+	}
+}
+
+
+/*########################################################################################################################*
+*-------------------------------------------------------Window common-----------------------------------------------------*
+*#########################################################################################################################*/
+void Window_PreInit(void) {
+	DisplayInfo.CursorVisible = true;
+}
+
+void Window_Init(void) {
+	Input.Sources = INPUT_SOURCE_NORMAL;
+	fb_rotate = EnvInt("CC_FB_ROTATE", 180);
+	InitFramebuffer();
+
+	DisplayInfo.Width  = scr_w;
+	DisplayInfo.Height = scr_h;
+	DisplayInfo.Depth  = 32;   /* engine always works in a 32bpp bitmap; panel conv is ours */
+	/* Small round panel: shrink 2D UI so menus/buttons fit. */
+	DisplayInfo.ScaleX = 0.5f;
+	DisplayInfo.ScaleY = 0.5f;
+
+	Window_Main.Width    = scr_w;
+	Window_Main.Height   = scr_h;
+	Window_Main.Exists   = true;
+	Window_Main.Focused  = true;
+	Window_Main.UIScaleX = DEFAULT_UI_SCALE_X;
+	Window_Main.UIScaleY = DEFAULT_UI_SCALE_Y;
+	Window_Alt = Window_Main;
+
+	InitButtons();
+	InitTouch();
+	Platform_Flags |= PLAT_FLAG_SINGLE_PROCESS;
+}
+
+void Window_Free(void) {
+	if (fb_mem && fb_mem != MAP_FAILED) munmap(fb_mem, fb_memlen);
+	if (fb_fd   >= 0) close(fb_fd);
+	if (ts_fd   >= 0) { ioctl(ts_fd,  EVIOCGRAB, (void*)0); close(ts_fd); }
+	if (key_fd  >= 0) { ioctl(key_fd, EVIOCGRAB, (void*)0); close(key_fd); }
+	if (gate_fd >= 0) close(gate_fd);
+	fb_fd = ts_fd = key_fd = gate_fd = -1;
+}
+
+static void DoCreateWindow(int width, int height) {
+	Window_Main.Exists   = true;
+	Window_Main.Focused  = true;
+	Window_Main.UIScaleX = DEFAULT_UI_SCALE_X;
+	Window_Main.UIScaleY = DEFAULT_UI_SCALE_Y;
+}
+void Window_Create2D(int width, int height) { DoCreateWindow(width, height); }
+void Window_Create3D(int width, int height) { DoCreateWindow(width, height); }
+
+void Window_Destroy(void) { }
+
+void Window_SetTitle(const cc_string* title) { }
+void Clipboard_GetText(cc_string* value)     { }
+void Clipboard_SetText(const cc_string* value) { }
+
+int Window_GetWindowState(void)     { return WINDOW_STATE_FULLSCREEN; }
+cc_result Window_EnterFullscreen(void) { return 0; }
+cc_result Window_ExitFullscreen(void)  { return 0; }
+int Window_IsObscured(void)         { return 0; }
+
+void Window_Show(void)     { }
+void Window_SetSize(int width, int height) { }
+void Window_RequestClose(void) {
+	Window_Main.Exists = false;
+	Event_RaiseVoid(&WindowEvents.Closing);
+}
+
+void Window_ProcessEvents(float delta) {
+	ProcessButtons(delta);
+	ProcessTouch();
+}
+
+void Gamepads_PreInit(void) { }
+void Gamepads_Init(void)    { }
+void Gamepads_Process(float delta) { }
+
+static void Cursor_GetRawPos(int* x, int* y) { *x = touchX; *y = touchY; }
+void Cursor_SetPosition(int x, int y) { }
+static void Cursor_DoSetVisible(cc_bool visible) { }
+
+static void ShowDialogCore(const char* title, const char* msg) {
+	Platform_LogConst(title);
+	Platform_LogConst(msg);
+}
+
+cc_result Window_OpenFileDialog(const struct OpenFileDialogArgs* args) { return ERR_NOT_SUPPORTED; }
+cc_result Window_SaveFileDialog(const struct SaveFileDialogArgs* args) { return ERR_NOT_SUPPORTED; }
+
+void OnscreenKeyboard_Open(struct OpenKeyboardArgs* args) { }
+void OnscreenKeyboard_SetText(const cc_string* text)      { }
+void OnscreenKeyboard_Close(void) { }
+
+/* Touch drag-to-look raises PointerEvents.RawMoved directly, so no cursor centring is needed. */
+void Window_EnableRawMouse(void)  { Input.RawMode = true;  lookHasPrev = false; }
+void Window_UpdateRawMouse(void)  { }
+void Window_DisableRawMouse(void) { Input.RawMode = false; lookHasPrev = false; }
+#endif

--- a/src/posix/Plat_Linux.inc
+++ b/src/posix/Plat_Linux.inc
@@ -102,7 +102,7 @@ void CrashHandler_DumpRegisters(void* ctx, cc_string* str) {
 #elif defined __mips__
 	mcontext_t* r = &((ucontext_t*)ctx)->uc_mcontext;
 	#define RREG(reg) &r->reg
-	#define RNUM(reg) &r->greps[reg]
+	#define RNUM(reg) &r->gregs[reg]
 
 	String_Format4(str, "r1 =%x r2 =%x r3 =%x r4 =%x" _NL, RNUM(1),  RNUM(2),  RNUM(3),  RNUM(4));
 	String_Format4(str, "r5 =%x r6 =%x r7 =%x r8 =%x" _NL, RNUM(5),  RNUM(6),  RNUM(7),  RNUM(8));
@@ -112,7 +112,7 @@ void CrashHandler_DumpRegisters(void* ctx, cc_string* str) {
 	String_Format4(str, "r21=%x r22=%x r23=%x r24=%x" _NL, RNUM(21), RNUM(22), RNUM(23), RNUM(24));
 	String_Format4(str, "r25=%x r26=%x r27=%x r28=%x" _NL, RNUM(25), RNUM(26), RNUM(27), RNUM(28));
 	String_Format4(str, "sp =%x fp =%x ra =%x pc =%x" _NL, RNUM(29), RNUM(30), RNUM(31), RREG(pc));
-	String_Format3(str, "lo =%x hi =%x" _NL,               &r->mdlo, &r->mdhi);
+	String_Format2(str, "lo =%x hi =%x" _NL,               &r->mdlo, &r->mdhi);
 #elif defined __riscv
 	mcontext_t* r = &((ucontext_t*)ctx)->uc_mcontext;
 	#define RREG(reg) &r->__gregs[REG_##reg]


### PR DESCRIPTION
Adds initial support for the **Snowsky Echo Disc** (FiiO) — an **Ingenic X2000**
(MIPS32r2 LE) embedded-Linux music player with a 360x360 round LCD and a
capacitive touchscreen. No GPU, so it uses the software rasteriser with a new
raw-framebuffer + evdev windowing backend and the existing POSIX platform layer.
Currently works using the buttons from the device itself (explained later), but does 
not yet have implemented network support, for instance. 

Built with zig and tested on real hardware: it renders the launcher and a
singleplayer world on the panel, and all inputs work.

### What it adds
- **`src/Window_Fbdev.c`** — the backend:
- Display: `/dev/fb0` via `FBIOGET_*SCREENINFO` + `mmap`; converts ClassiCube's
    32bpp bitmap to the panel's pixel format (16bpp RGB565 or 32bpp), read from the
    driver so one binary handles either. 180° rotation for the upside-down panel
    (`CC_FB_ROTATE`).
- Input: standard evdev, matched by device name — `x2000_key` (buttons) and
    `cst816` (touchscreen).
- **`src/Core.h`** — `CC_WIN_BACKEND_FBDEV` and a `PLAT_SNOWSKY` platform branch
(reuses Linux/POSIX; software render, null audio, no freetype/resources/networking).
- **`misc/snowsky/`** — `Makefile` (zig cross-compile + NaN2008 ELF patch),
`readme.md`, `run.sh`, `mq_decoy.c`, `set_nan2008.py`.

### Controls
| Input | Action |
|-------|--------|
| Vol+ / Vol− | Move forward / back (W / S) |
| Play/Pause | Action — place/break (left click) |
| Power (tap) | Jump (space) |
| Touch | Look (in game) / pointer + click (menus) |

### Included bug fixes (not Snowsky-specific)
- **`src/posix/Plat_Linux.inc`** — two compile errors in the `__mips__` branch of
`CrashHandler_DumpRegisters` (`r->greps` → `r->gregs`; a `String_Format3` call
with two args → `String_Format2`). That branch had never been compiled, so no
MIPS Linux target could build it. Happy to split these into a separate PR if
preferred.
- **`src/Platform_Posix.c`** — on static-musl builds, `dlsym(RTLD_NEXT,
"pthread_setname_np")` has no dynamic linker to walk and crashes; call
`pthread_setname_np` directly (scoped to `PLAT_SNOWSKY`).

### Note on running it
The device's stock firmware fights a takeover in two ways that `misc/snowsky/run.sh`
handles: a ~10s **hardware watchdog** on `/dev/jz_watchdog` (fed by `mq_player`; kill
it and the SoC hard-resets — the launcher feeds/stops it via the stock `cmd_watchdog`),
and a **supervisor** (`fiio_init.sh`) that relaunches the UI and kills wifi/backlight
(kept happy with decoy processes). See `misc/snowsky/readme.md`.