### PR TITLE
Add an option to enable face culling for block entities

### DIFF
--- a/src/Entity.c
+++ b/src/Entity.c
@@ -139,6 +139,9 @@ void Entity_SetModel(struct Entity* e, const cc_string* model) {
 
 	if (e->Flags & ENTITY_FLAG_HAS_MODELVB)
 		Gfx_DeleteDynamicVb(&e->ModelVB);
+
+	if (String_CaselessEqualsConst(&scale, "fc"))
+		e->Flags |= ENTITY_FLAG_BLOCK_MODEL_FACE_CULLING;
 }
 
 void Entity_UpdateModelBounds(struct Entity* e) {

--- a/src/Entity.h
+++ b/src/Entity.h
@@ -105,6 +105,8 @@ struct EntityVTABLE {
 /* Whether in classic mode, to slightly adjust this entity downwards when rendering it */
 /*  to replicate the behaviour of the original vanilla classic client */
 #define ENTITY_FLAG_CLASSIC_ADJUST 0x04
+/* Forcibly enable face culling for rendering this entity if it represents a block model */
+#define ENTITY_FLAG_BLOCK_MODEL_FACE_CULLING 0x08
 
 /* Contains a model, along with position, velocity, and rotation. May also contain other fields and properties. */
 struct Entity {

--- a/src/Model.c
+++ b/src/Model.c
@@ -2218,7 +2218,7 @@ static void BlockModel_DrawParts(void) {
 }
 
 static void BlockModel_Draw(struct Entity* e) {
-	cc_bool sprite;
+	cc_bool sprite, faceCulling;
 	int i;
 
 	bModel_block = e->ModelBlock;
@@ -2235,9 +2235,10 @@ static void BlockModel_Draw(struct Entity* e) {
 	sprite = Blocks.Draw[bModel_block] == DRAW_SPRITE;
 	BlockModel_BuildParts(e, sprite);
 
-	if (sprite) Gfx_SetFaceCulling(true);
+	faceCulling = (sprite || (e->Flags & ENTITY_FLAG_BLOCK_MODEL_FACE_CULLING));
+	if (faceCulling) Gfx_SetFaceCulling(true);
 	BlockModel_DrawParts();
-	if (sprite) Gfx_SetFaceCulling(false);
+	if (faceCulling) Gfx_SetFaceCulling(false);
 }
 
 static struct Model block_model = { "block", NULL, &human_tex,


### PR DESCRIPTION
Allow servers to enable face culling optimization on client side when rendering an entity with a block model. This could be done by sending a CPE ChangeModel packet specifying `blockId|fc` as the model name. Useful when there is a need to replicate the look of a block with transparent pixels, in the context of being used as an entity model.