### PR TITLE
set TCP_NODELAY to posix and windows sockets

### DIFF
--- a/misc/windows/min-winsock2.h
+++ b/misc/windows/min-winsock2.h
@@ -62,6 +62,8 @@ typedef _UINT_PTR SOCKET;
 
 #define IPPROTO_TCP 6
 
+#define TCP_NODELAY 0x0001
+
 #define SOL_SOCKET 0xffff
 
 #define SO_ERROR 0x1007
@@ -136,6 +138,7 @@ CC_WINSOCK_FUNC int (WINAPI *_shutdown)(SOCKET s, int how);
 
 CC_WINSOCK_FUNC int (WINAPI *_ioctlsocket)(SOCKET s, long cmd, u_long* argp);
 CC_WINSOCK_FUNC int (WINAPI *_getsockopt)(SOCKET s, int level, int optname, char* optval, int* optlen);
+CC_WINSOCK_FUNC int (WINAPI *_setsockopt)(SOCKET s, int level, int optname, const char* optval, int optlen);
 CC_WINSOCK_FUNC int (WINAPI *_recv)(SOCKET s, char* buf, int len, int flags);
 CC_WINSOCK_FUNC int (WINAPI *_send)(SOCKET s, const char FAR * buf, int len, int flags);
 CC_WINSOCK_FUNC int (WINAPI *_select)(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, const struct timeval* timeout);
@@ -151,6 +154,7 @@ static void Winsock_LoadDynamicFuncs(void) {
 		DynamicLib_ReqSym(socket),          DynamicLib_ReqSym(closesocket),
 		DynamicLib_ReqSym(connect),         DynamicLib_ReqSym(shutdown),
 		DynamicLib_ReqSym(ioctlsocket),     DynamicLib_ReqSym(getsockopt),
+		DynamicLib_ReqSym(setsockopt),
 		DynamicLib_ReqSym(gethostbyname),
 		DynamicLib_OptSym(getaddrinfo),     DynamicLib_OptSym(freeaddrinfo),
 		DynamicLib_ReqSym(recv), DynamicLib_ReqSym(send), DynamicLib_ReqSym(select)

--- a/src/Platform_Posix.c
+++ b/src/Platform_Posix.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
@@ -787,6 +788,8 @@ cc_result Socket_Create(cc_socket* s, cc_sockaddr* addr) {
 	*s = socket(raw->sa_family, SOCK_STREAM, IPPROTO_TCP);
 	if (*s == -1) return errno;
 
+	int nodelay = 1;
+	setsockopt(*s, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
 	return 0;
 }
 

--- a/src/Platform_Windows.c
+++ b/src/Platform_Windows.c
@@ -686,6 +686,8 @@ cc_result Socket_Create(cc_socket* s, cc_sockaddr* addr) {
 	*s = _socket(raw_addr->sa_family, SOCK_STREAM, IPPROTO_TCP);
 	if (*s == -1) return _WSAGetLastError();
 
+	int nodelay = 1;
+	_setsockopt(*s, IPPROTO_TCP, TCP_NODELAY, (const char*)&nodelay, sizeof(nodelay));
 	return 0;
 }
 


### PR DESCRIPTION
Tested on linux, macos and windows builds.

`TCP_NODELAY` is important to games requiring low latency.
Websockets does this by default, so the web version is not affected by this, and ping difference can be observed between web and native clients.