### PR TITLE
Set default Windows CE ARM target from armv5te to armv4t

### DIFF
--- a/misc/makefiles/wince.mk
+++ b/misc/makefiles/wince.mk
@@ -12,7 +12,8 @@ include misc/makefiles/common_config.mk
 
 ifeq ($(WINCE_ARCH),arm)
 	CC      := arm-mingw32ce-gcc
-	CFLAGS	:= $(CFLAGS) -march=armv5te
+	WINCE_CPU ?= armv4t
+	CFLAGS	:= $(CFLAGS) -march=$(WINCE_CPU)
 else ifeq  ($(WINCE_ARCH),i386)
 	CC      := i386-mingw32ce-gcc
 else

--- a/misc/makefiles/wince.mk
+++ b/misc/makefiles/wince.mk
@@ -3,17 +3,19 @@
 #-----------------------------
 SOURCE_DIRS := src src/wince third_party/bearssl
 BUILD_DIR	:= build/wince
-WINCE_ARCH	?= arm
+WINCE_ARCH	?= armv4
 
 CFLAGS	:= -DUNICODE -D_WIN32_WCE -std=gnu99 -fno-ident
 LDFLAGS	:=
 LIBS 	:= -lcoredll -lws2
 include misc/makefiles/common_config.mk
 
-ifeq ($(WINCE_ARCH),arm)
+ifeq ($(WINCE_ARCH),armv4)
 	CC      := arm-mingw32ce-gcc
-	WINCE_CPU ?= armv4t
-	CFLAGS	:= $(CFLAGS) -march=$(WINCE_CPU)
+	CFLAGS	:= $(CFLAGS) -march=armv4t
+else ifeq ($(WINCE_ARCH),armv5)
+	CC      := arm-mingw32ce-gcc
+	CFLAGS	:= $(CFLAGS) -march=armv5te
 else ifeq  ($(WINCE_ARCH),i386)
 	CC      := i386-mingw32ce-gcc
 else


### PR DESCRIPTION
Now the default target is set to ARMv4T, and it works without any problems. (I tested it on the Cerf emulator, which emulates an ARM920T CPU — ARMv4T only, no ARMv5TE support — running Windows Mobile 6.0. Note that WM6.0 itself supports both ARMv4 and ARMv5 devices; the limitation here is the specific hardware/emulator, not the OS.)

Also added the ability to set your own architecture, and it will be possible to compile everything the same way with the armv5te architecture by simply writing make wince WINCE_CPU=(architecture).

This is also necessary to add support for new devices, but already on the ARMv4T architecture.

<img width="598" height="718" alt="{FAAFFB6F-8E15-4088-95A5-B026F28AAF8A}" src="https://github.com/user-attachments/assets/cc61aba0-6f0d-47ad-9344-36487b31e01a" />
